### PR TITLE
Do not try to install & initialize module if in kernel suppor has been specifically disabled (ie. TABLE < 0)

### DIFF
--- a/debian/ngcp-rtpengine-daemon.init
+++ b/debian/ngcp-rtpengine-daemon.init
@@ -70,20 +70,22 @@ case "$1" in
   start)
 
 	echo -n "Starting $DESC: $NAME"
-        set +e
-	modprobe xt_MEDIAPROXY
-	echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
-	iptables -N mediaproxy 2> /dev/null
-	iptables -D INPUT -j mediaproxy 2> /dev/null
-	iptables -I INPUT -j mediaproxy
-	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	iptables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
-	ip6tables -N mediaproxy 2> /dev/null
-	ip6tables -D INPUT -j mediaproxy 2> /dev/null
-	ip6tables -I INPUT -j mediaproxy
-	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	ip6tables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
-	set -e
+        if [ $TABLE -ge 0 ]; then \
+                set +e
+        	modprobe xt_MEDIAPROXY
+        	echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
+        	iptables -N mediaproxy 2> /dev/null
+        	iptables -D INPUT -j mediaproxy 2> /dev/null
+        	iptables -I INPUT -j mediaproxy
+        	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	iptables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
+        	ip6tables -N mediaproxy 2> /dev/null
+        	ip6tables -D INPUT -j mediaproxy 2> /dev/null
+        	ip6tables -I INPUT -j mediaproxy
+        	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	ip6tables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
+        	set -e
+        fi
 	start-stop-daemon --start --quiet --pidfile $PIDFILE \
 		--exec $DAEMON -- $OPTIONS || echo -n " already running"
 	log_end_msg $?
@@ -95,15 +97,17 @@ case "$1" in
 	if [ "$?" -ne 0 ]; then
 		return $?
 	fi
-	set +e
-	echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
-	iptables -D INPUT -j mediaproxy 2> /dev/null
-	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	ip6tables -D INPUT -j mediaproxy 2> /dev/null
-	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	rmmod ipt_MEDIAPROXY 2>/dev/null
-	rmmod xt_MEDIAPROXY 2>/dev/null
-	set -e
+        if [ $TABLE -ge 0 ]; then \
+        	set +e
+        	echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
+        	iptables -D INPUT -j mediaproxy 2> /dev/null
+        	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	ip6tables -D INPUT -j mediaproxy 2> /dev/null
+        	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	rmmod ipt_MEDIAPROXY 2>/dev/null
+        	rmmod xt_MEDIAPROXY 2>/dev/null
+        	set -e
+        fi
 	rm -f $PIDFILE
 	log_end_msg $?
 	;;
@@ -116,25 +120,27 @@ case "$1" in
 		return $?
 	fi
 	rm -f $PIDFILE
-	sleep 1
-	set +e
-	if [ -e /proc/mediaproxy/control ]; then
-		echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
-	fi
-	iptables -D INPUT -j mediaproxy 2> /dev/null
-	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	ip6tables -D INPUT -j mediaproxy 2> /dev/null
-	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
-	rmmod ipt_MEDIAPROXY 2>/dev/null
-	rmmod xt_MEDIAPROXY 2>/dev/null
-	modprobe xt_MEDIAPROXY
-	iptables -N mediaproxy 2> /dev/null
-	iptables -I INPUT -j mediaproxy
-	iptables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
-	ip6tables -N mediaproxy 2> /dev/null
-	ip6tables -I INPUT -j mediaproxy
-	ip6tables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
-	set -e
+        if [ $TABLE -ge 0 ]; then \
+        	sleep 1
+        	set +e
+        	if [ -e /proc/mediaproxy/control ]; then
+        		echo "del $TABLE" > /proc/mediaproxy/control 2>/dev/null
+        	fi
+        	iptables -D INPUT -j mediaproxy 2> /dev/null
+        	iptables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	ip6tables -D INPUT -j mediaproxy 2> /dev/null
+        	ip6tables -D mediaproxy -p udp -j MEDIAPROXY --id $TABLE 2>/dev/null
+        	rmmod ipt_MEDIAPROXY 2>/dev/null
+        	rmmod xt_MEDIAPROXY 2>/dev/null
+        	modprobe xt_MEDIAPROXY
+        	iptables -N mediaproxy 2> /dev/null
+        	iptables -I INPUT -j mediaproxy
+        	iptables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
+        	ip6tables -N mediaproxy 2> /dev/null
+        	ip6tables -I INPUT -j mediaproxy
+        	ip6tables -I mediaproxy -p udp -j MEDIAPROXY --id $TABLE
+        	set -e
+        fi
 	start-stop-daemon --start --quiet --pidfile \
 		$PIDFILE --exec $DAEMON  -- $OPTIONS
 	log_end_msg $?


### PR DESCRIPTION
Trying to disable kernel forwarding support (by setting TABLE=-1) on debian systems fails. This PR fixes it by taking it into account and not performing any kernel initialisation procedures in such a case.
