### PR TITLE
fix null/empty string check in ng_call_stats

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -823,7 +823,7 @@ void ng_call_stats(struct call *call, const str *fromtag, const str *totag, benc
 stats:
 	match_tag = (totag && totag->s && totag->len) ? totag : fromtag;
 
-	if (!match_tag) {
+	if (!match_tag || !match_tag->len) {
 		for (l = call->monologues; l; l = l->next) {
 			ml = l->data;
 			ng_stats_monologue(tags, ml, totals);


### PR DESCRIPTION
If no tag is specified in the `query` command, then `fromtag` and `totag` are NULL strings, but not NULL pointers.
