### PR TITLE
clear crypto for BOTH legs when in passthrough mode

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1916,10 +1916,17 @@ static void __generate_crypto(const struct sdp_ng_flags *flags, struct call_medi
 
 	if (!this->protocol || !this->protocol->srtp || MEDIA_ISSET(this, PASSTHRU)) {
 		cp->crypto_suite = NULL;
+		/* clear crypto for the this leg b/c we are in passthrough mode */
 		MEDIA_CLEAR(this, DTLS);
 		MEDIA_CLEAR(this, SDES);
 		MEDIA_CLEAR(this, SETUP_PASSIVE);
 		MEDIA_CLEAR(this, SETUP_ACTIVE);
+		/* clear crypto for the other leg as well b/c passthrough only works if it is done for both legs */
+		MEDIA_CLEAR(other, DTLS);
+		MEDIA_CLEAR(other, SDES);
+		MEDIA_CLEAR(other, SETUP_PASSIVE);
+		MEDIA_CLEAR(other, SETUP_ACTIVE);
+
 		return;
 	}
 


### PR DESCRIPTION
In ice_offer, and generate_crypto the PASSTHRU flag is set and checked respectively to determine whether the rtpengine should act as a dtls client.

In generate_crypto, it checks if PASSTHRU is set, then unsets all the cryto flags for "this" leg of the monologue, but not the "other" leg of the monologue.

If one leg is passthru, they both need to be passthru - if not then there is some broken half ice/dtls client stuff going on and it fails.  

I tested this patch with 2 WebRTC clients (SIP.js) and rtpengine appropriately proxied the ice/dtls through to each endpoint and they setup ice/dtls between each other.