### PR TITLE
Resolves ROC inconsistancies when encrypting SRTP

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -161,8 +161,6 @@ static int call_avpf2avp_rtcp(str *s, struct packet_stream *);
 static int call_savpf2avp_rtcp(str *s, struct packet_stream *);
 //static int call_savpf2savp_rtcp(str *s, struct packet_stream *);
 
-static void unkernelize(struct packet_stream *);
-
 /* ********** */
 
 static const struct streamhandler_io __shio_noop = {

--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -572,3 +572,36 @@ void crypto_dump_keys(struct crypto_context *in, struct crypto_context *out) {
 	ilog(LOG_DEBUG, "SRTP keys, outgoing:");
 	dump_key(out);
 }
+
+struct rtp_ssrc_entry *find_ssrc(u_int32_t ssrc, struct rtp_ssrc_entry *list) {
+	for (; list; list = list->next) {
+		if (list->ssrc == ssrc)
+			return list;
+	}
+	return 0;
+}
+
+void add_ssrc_entry(struct rtp_ssrc_entry *ent, struct rtp_ssrc_entry *list) {
+	struct rtp_ssrc_entry *cur;
+	for (cur = list; list; list = list->next)
+		cur = list;
+	cur->next = ent;
+}
+
+struct rtp_ssrc_entry *create_ssrc_entry(u_int32_t ssrc, u_int64_t index) {
+	struct rtp_ssrc_entry *ent;
+	ent = malloc(sizeof(struct rtp_ssrc_entry));
+	ent->ssrc = ssrc;
+	ent->index = index;
+	ent->next = 0;
+	return ent;
+}
+
+void free_ssrc_list(struct rtp_ssrc_entry *list) {
+	struct rtp_ssrc_entry *tmp;
+	for (tmp = list; tmp; ) {
+		tmp = list->next;
+		free(list);
+		list = tmp;
+	}
+}

--- a/daemon/crypto.h
+++ b/daemon/crypto.h
@@ -88,10 +88,16 @@ struct crypto_context {
 	void *session_key_ctx[2];
 
 	int have_session_key:1;
+
+	struct rtp_ssrc_entry   *ssrc_list;
+	int                     ssrc_mismatch;
 };
 
-
-
+struct rtp_ssrc_entry {
+	u_int32_t ssrc;
+	u_int64_t index;
+	struct rtp_ssrc_entry *next;
+};
 
 extern const struct crypto_suite crypto_suites[];
 extern const int num_crypto_suites;
@@ -102,7 +108,10 @@ const struct crypto_suite *crypto_find_suite(const str *);
 int crypto_gen_session_key(struct crypto_context *, str *, unsigned char, int);
 void crypto_dump_keys(struct crypto_context *in, struct crypto_context *out);
 
-
+struct rtp_ssrc_entry *find_ssrc(u_int32_t, struct rtp_ssrc_entry *);
+void add_ssrc_entry(struct rtp_ssrc_entry *, struct rtp_ssrc_entry *);
+struct rtp_ssrc_entry *create_ssrc_entry(u_int32_t, u_int64_t);
+void free_ssrc_list(struct rtp_ssrc_entry *);
 
 
 INLINE int crypto_encrypt_rtp(struct crypto_context *c, struct rtp_header *rtp,

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -1908,7 +1908,7 @@ static u_int64_t packet_index(struct re_crypto_context *c,
 	if (unlikely(!s->last_index))
 		s->last_index = seq;
 
-  /* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
+	/* rfc 3711 appendix A, modified, and sections 3.3 and 3.3.1 */
 	s_l = (s->last_index & 0x00000000ffffULL);
 	roc = (s->last_index & 0xffffffff0000ULL) >> 16;
 	v = 0;

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -2264,11 +2264,19 @@ src_check_ok:
 
 	rtp_pt_idx = rtp_payload_type(rtp.header, &g->target);
 
-	pkt_idx_u = pkt_idx = packet_index(&g->decrypt, &g->target.decrypt, rtp.header);
-	if (srtp_auth_validate(&g->decrypt, &g->target.decrypt, &rtp, &pkt_idx))
-		goto skip_error;
-	if (pkt_idx != pkt_idx_u)
-		update_packet_index(&g->decrypt, &g->target.decrypt, pkt_idx);
+	if ((&g->decrypt)->cipher->decrypt) {
+		pkt_idx_u = pkt_idx = packet_index(&g->decrypt, &g->target.decrypt, rtp.header);
+		if (srtp_auth_validate(&g->decrypt, &g->target.decrypt, &rtp, &pkt_idx))
+			goto skip_error;
+		if (pkt_idx != pkt_idx_u)
+			update_packet_index(&g->decrypt, &g->target.decrypt, pkt_idx);
+	} else {
+		pkt_idx_u = pkt_idx = packet_index(&g->encrypt, &g->target.encrypt, rtp.header);
+
+		if (pkt_idx != pkt_idx_u)
+			update_packet_index(&g->encrypt, &g->target.encrypt, pkt_idx);
+	}
+
 	if (srtp_decrypt(&g->decrypt, &g->target.decrypt, &rtp, pkt_idx))
 		goto skip_error;
 

--- a/kernel-module/xt_RTPENGINE.h
+++ b/kernel-module/xt_RTPENGINE.h
@@ -82,6 +82,7 @@ struct rtpengine_target_info {
 
 	struct rtpengine_srtp		decrypt;
 	struct rtpengine_srtp		encrypt;
+        u_int32_t                       ssrc; // Expose the SSRC to userspace when we resync.
 
 	unsigned char			payload_types[NUM_PAYLOAD_TYPES]; /* must be sorted */
 	unsigned int			num_payload_types;


### PR DESCRIPTION
@mclazarus and I resolved https://github.com/sipwise/rtpengine/issues/102.  We addressed the following:

1. Uses the proper ROC in kernel space when encrypting.
2. Track all SSRCs we've seen along with the last ROC associated with each.  If the SSRC is used again we revert the ROC, otherwise it's zeroed out.
3. Re-implemented RFC 3711 index determination to avoid a few dead spots in the sequence numbers.