### PR TITLE
Bypass the randomization of get_consecutive_ports()

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1750,7 +1750,7 @@ struct stream_fd *__stream_fd_new(struct udp_fd *fd, struct call *call) {
 }
 
 static struct endpoint_map *__get_endpoint_map(struct call_media *media, unsigned int num_ports,
-		const struct endpoint *ep)
+		const struct endpoint *ep, unsigned int wanted_start_port)
 {
 	GSList *l;
 	struct endpoint_map *em;
@@ -1802,7 +1802,7 @@ static struct endpoint_map *__get_endpoint_map(struct call_media *media, unsigne
 alloc:
 	if (num_ports > G_N_ELEMENTS(fd_arr))
 		return NULL;
-	if (__get_consecutive_ports(fd_arr, num_ports, 0, media->call))
+	if (__get_consecutive_ports(fd_arr, num_ports, wanted_start_port, media->call))
 		return NULL;
 
 	__C_DBG("allocating stream_fds for %u ports", num_ports);
@@ -1841,10 +1841,10 @@ static void __assign_stream_fds(struct call_media *media, GList *sfds) {
 		ice_restart(media->ice_agent);
 }
 
-static int __wildcard_endpoint_map(struct call_media *media, unsigned int num_ports) {
+static int __wildcard_endpoint_map(struct call_media *media, unsigned int num_ports, unsigned int wanted_start_port) {
 	struct endpoint_map *em;
 
-	em = __get_endpoint_map(media, num_ports, NULL);
+	em = __get_endpoint_map(media, num_ports, NULL, wanted_start_port);
 	if (!em)
 		return -1;
 
@@ -2457,7 +2457,8 @@ static void __ice_start(struct call_media *media) {
 
 /* called with call->master_lock held in W */
 int monologue_offer_answer(struct call_monologue *other_ml, GQueue *streams,
-		const struct sdp_ng_flags *flags)
+		const struct sdp_ng_flags *flags,
+        unsigned int wanted_start_port1, unsigned int wanted_start_port2)
 {
 	struct stream_params *sp;
 	GList *media_iter, *ml_media, *other_ml_media;
@@ -2595,7 +2596,7 @@ int monologue_offer_answer(struct call_monologue *other_ml, GQueue *streams,
 
 		/* get that many ports for each side, and one packet stream for each port, then
 		 * assign the ports to the streams */
-		em = __get_endpoint_map(media, num_ports, &sp->rtp_endpoint);
+		em = __get_endpoint_map(media, num_ports, &sp->rtp_endpoint, wanted_start_port1);
 		if (!em)
 			goto error;
 
@@ -2606,7 +2607,7 @@ int monologue_offer_answer(struct call_monologue *other_ml, GQueue *streams,
 			/* new streams created on OTHER side. normally only happens in
 			 * initial offer. create a wildcard endpoint_map to be filled in
 			 * when the answer comes. */
-			if (__wildcard_endpoint_map(other_media, num_ports))
+			if (__wildcard_endpoint_map(other_media, num_ports, wanted_start_port2))
 				goto error;
 		}
 

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -499,7 +499,9 @@ struct call *call_get_opmode(const str *callid, struct callmaster *m, enum call_
 struct call_monologue *call_get_mono_dialogue(struct call *call, const str *fromtag, const str *totag,
 		const str *viabranch);
 struct call *call_get(const str *callid, struct callmaster *m);
-int monologue_offer_answer(struct call_monologue *monologue, GQueue *streams, const struct sdp_ng_flags *flags);
+int monologue_offer_answer(struct call_monologue *monologue, GQueue *streams,
+        const struct sdp_ng_flags *flags,
+        unsigned int wanted_start_port1, unsigned int wanted_start_port2);
 int call_delete_branch(struct callmaster *m, const str *callid, const str *branch,
 	const str *fromtag, const str *totag, bencode_item_t *output, int delete_delay);
 void call_destroy(struct call *);

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -179,7 +179,7 @@ static str *call_update_lookup_udp(char **out, struct callmaster *m, enum call_o
 		goto addr_fail;
 
 	g_queue_push_tail(&q, &sp);
-	i = monologue_offer_answer(monologue, &q, NULL);
+	i = monologue_offer_answer(monologue, &q, NULL, 0, 0);
 	g_queue_clear(&q);
 
 	if (i)
@@ -332,7 +332,7 @@ static str *call_request_lookup_tcp(char **out, struct callmaster *m, enum call_
 		ilog(LOG_WARNING, "Invalid dialogue association");
 		goto out2;
 	}
-	if (monologue_offer_answer(monologue, &s, NULL))
+	if (monologue_offer_answer(monologue, &s, NULL, 0, 0))
 		goto out2;
 
 	ret = streams_print(&monologue->active_dialogue->medias, 1, s.length, NULL, SAF_TCP);
@@ -709,7 +709,7 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 
 	chopper = sdp_chopper_new(&sdp);
 	bencode_buffer_destroy_add(output->buffer, (free_func_t) sdp_chopper_destroy, chopper);
-	ret = monologue_offer_answer(monologue, &streams, &flags);
+	ret = monologue_offer_answer(monologue, &streams, &flags, 0, 0);
 	if (!ret)
 		ret = sdp_replace(chopper, &parsed, monologue->active_dialogue, &flags);
 


### PR DESCRIPTION
One solution(the one presented) is to add two more wanted_ports to the monologue_offer answer() will eventually call get_consecutive ports for each of the wanted port.
 
Another solution to this bypassing would be to retain the wanted_ports in a structure (like callmaster) and call the get_endpoint_map()->get_consecutive_ports() with the values found there(defaulted to 0).

What do you think about it?