### PR TITLE
rtpengine.init now working with firewalld

### DIFF
--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -56,10 +56,13 @@ build_opts() {
 	fi
 	shopt -u nocasematch
 
-	if [[ -n "$RTP_IP" ]]
-	then
-		OPTS+=" --interface=$RTP_IP"
-	fi
+        if [[ -n "$RTP_IP" ]]
+        then
+                for IP in "${RTP_IP[@]}"
+                do
+                        OPTS+=" --interface=$IP"
+                done
+        fi
 
 	if [[ -n "$RTP_ADV_IP" ]]
 	then
@@ -68,7 +71,10 @@ build_opts() {
 
 	if [[ -n "$RTP_IP6" ]]
 	then
-		OPTS+=" --interface=$RTP_IP6"
+		for IP in "${RTP_IP6[@]}"
+                do
+                        OPTS+=" --interface=$IP"
+                done
 		IP6=1
 	fi
 

--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -36,7 +36,6 @@ RETVAL=0
 
 OPTS="--pidfile $pidfile"
 MODULE=0
-IP6=0
 
 build_opts() {
 	shopt -s nocasematch
@@ -63,25 +62,6 @@ build_opts() {
                         OPTS+=" --interface=$IP"
                 done
         fi
-
-	if [[ -n "$RTP_ADV_IP" ]]
-	then
-		OPTS+="!$RTP_ADV_IP"
-	fi
-
-	if [[ -n "$RTP_IP6" ]]
-	then
-		for IP in "${RTP_IP6[@]}"
-                do
-                        OPTS+=" --interface=$IP"
-                done
-		IP6=1
-	fi
-
-	if [[ -n "$RTP_ADV_IP6" ]]
-	then
-		OPTS+="!$RTP_ADV_IP6"
-	fi
 
 	if [[ -n "$LISTEN_TCP" ]]
 	then
@@ -217,25 +197,16 @@ start() {
 			firewall-cmd --direct --add-chain ipv4 filter rtpengine
 			firewall-cmd --direct --add-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
 			firewall-cmd --direct --add-rule ipv4 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
-			if [[ $IP6 == 1 ]]
-			then
-				firewall-cmd --direct --add-rule ipv6 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
-  			fi
 			firewall-cmd --reload
 		else
 			iptables -N rtpengine
 			# We insert the rtpengine rule at the top of the input chain
 			iptables -t filter -I INPUT_prefilter -j rtpengine
 			iptables -I rtpengine -p udp -j RTPENGINE --id $TABLE
-			if [[ $IP6 == 1 ]]
-			then
-    				ip6tables -I rtpengine -p udp -j RTPENGINE --id $TABLE
-			fi
   		fi
 
 		cat <<EOF > "$cachefile"
 CUR_TABLE=$TABLE
-CUR_IP6=$IP6
 EOF
 	fi
         echo -n $"Starting $prog: "
@@ -260,19 +231,11 @@ stop() {
 		if [[ $? == 0 ]]
 		then
 			firewall-cmd --direct --remove-rules ipv4 filter rtpengine
-			if [[ $CUR_IP6 == 1 ]]
-			then
-				firewall-cmd --direct --remove-rules ipv6 filter rtpengine
-  			fi
 			firewall-cmd --direct --remove-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
 			firewall-cmd --direct --remove-chain ipv4 filter rtpengine
 			firewall-cmd --reload
 		else
 			iptables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
-			if [[ $CUR_IP6 == 1 ]]
-			then
-    				ip6tables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
-  			fi
 			iptables -t filter -D INPUT -j rtpengine
 			iptables -X rtpengine
 		fi

--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -197,13 +197,15 @@ start() {
 			firewall-cmd --direct --add-chain ipv4 filter rtpengine
 			firewall-cmd --direct --add-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
 			firewall-cmd --direct --add-rule ipv4 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
-			firewall-cmd --reload
+			firewall-cmd --direct --add-rule ipv6 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
+  			firewall-cmd --reload
 		else
 			iptables -N rtpengine
 			# We insert the rtpengine rule at the top of the input chain
 			iptables -t filter -I INPUT_prefilter -j rtpengine
 			iptables -I rtpengine -p udp -j RTPENGINE --id $TABLE
-  		fi
+			ip6tables -I rtpengine -p udp -j RTPENGINE --id $TABLE
+		fi
 
 		cat <<EOF > "$cachefile"
 CUR_TABLE=$TABLE
@@ -231,11 +233,13 @@ stop() {
 		if [[ $? == 0 ]]
 		then
 			firewall-cmd --direct --remove-rules ipv4 filter rtpengine
+			firewall-cmd --direct --remove-rules ipv6 filter rtpengine
 			firewall-cmd --direct --remove-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
 			firewall-cmd --direct --remove-chain ipv4 filter rtpengine
 			firewall-cmd --reload
 		else
 			iptables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
+			ip6tables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
 			iptables -t filter -D INPUT -j rtpengine
 			iptables -X rtpengine
 		fi

--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -36,6 +36,7 @@ RETVAL=0
 
 OPTS="--pidfile $pidfile"
 MODULE=0
+IP6=0
 
 build_opts() {
 	shopt -s nocasematch
@@ -55,13 +56,26 @@ build_opts() {
 	fi
 	shopt -u nocasematch
 
-        if [[ -n "$RTP_IP" ]]
-        then
-                for IP in "${RTP_IP[@]}"
-                do
-                        OPTS+=" --interface=$IP"
-                done
-        fi
+	if [[ -n "$RTP_IP" ]]
+	then
+		OPTS+=" --interface=$RTP_IP"
+	fi
+
+	if [[ -n "$RTP_ADV_IP" ]]
+	then
+		OPTS+="!$RTP_ADV_IP"
+	fi
+
+	if [[ -n "$RTP_IP6" ]]
+	then
+		OPTS+=" --interface=$RTP_IP6"
+		IP6=1
+	fi
+
+	if [[ -n "$RTP_ADV_IP6" ]]
+	then
+		OPTS+="!$RTP_ADV_IP6"
+	fi
 
 	if [[ -n "$LISTEN_TCP" ]]
 	then
@@ -179,15 +193,43 @@ start() {
 	if [[ $MODULE == 1 ]]
 	then
 		echo "Loading module for in-kernel packet forwarding"
-		rmmod xt_MEDIAPROXY 2> /dev/null
+		rmmod xt_RTPENGINE 2> /dev/null
 		modprobe xt_RTPENGINE
-		iptables -N rtpengine
-		iptables -t filter -A INPUT -j rtpengine
-		iptables -I rtpengine -p udp -j RTPENGINE --id $TABLE
-		ip6tables -I rtpengine -p udp -j RTPENGINE --id $TABLE
+		temp=`firewall-cmd --state 2>/dev/null`
+		if [[ $? == 0 ]]
+		then
+			# Using firewalld
+			# Need to check if the INPUT_prefilter chain is present (permanently)
+			firewall-cmd --permanent --direct --query-chain ipv4 filter INPUT_prefilter > /dev/null
+			if [[ $? != 0 ]]
+			then
+				firewall-cmd --permanent --direct --add-chain ipv4 filter INPUT_prefilter
+				firewall-cmd --permanent --direct --passthrough ipv4 -t filter -I INPUT -j INPUT_prefilter
+				firewall-cmd --reload
+			fi
+				
+			firewall-cmd --direct --add-chain ipv4 filter rtpengine
+			firewall-cmd --direct --add-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
+			firewall-cmd --direct --add-rule ipv4 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
+			if [[ $IP6 == 1 ]]
+			then
+				firewall-cmd --direct --add-rule ipv6 filter rtpengine 0 -p udp -j RTPENGINE --id $TABLE
+  			fi
+			firewall-cmd --reload
+		else
+			iptables -N rtpengine
+			# We insert the rtpengine rule at the top of the input chain
+			iptables -t filter -I INPUT_prefilter -j rtpengine
+			iptables -I rtpengine -p udp -j RTPENGINE --id $TABLE
+			if [[ $IP6 == 1 ]]
+			then
+    				ip6tables -I rtpengine -p udp -j RTPENGINE --id $TABLE
+			fi
+  		fi
 
 		cat <<EOF > "$cachefile"
 CUR_TABLE=$TABLE
+CUR_IP6=$IP6
 EOF
 	fi
         echo -n $"Starting $prog: "
@@ -208,11 +250,27 @@ stop() {
 		. "$cachefile"
 		echo "Unloading module for in-kernel packet forwarding"
 		echo "del $TABLE" > /proc/rtpengine/control
-		iptables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
-		ip6tables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
-		iptables -t filter -D INPUT -j rtpengine
-		iptables -X rtpengine
-#		rmmod xt_RTPENGINE
+		temp=`firewall-cmd --state 2>/dev/null`
+		if [[ $? == 0 ]]
+		then
+			firewall-cmd --direct --remove-rules ipv4 filter rtpengine
+			if [[ $CUR_IP6 == 1 ]]
+			then
+				firewall-cmd --direct --remove-rules ipv6 filter rtpengine
+  			fi
+			firewall-cmd --direct --remove-rule ipv4 filter INPUT_prefilter 0 -j rtpengine
+			firewall-cmd --direct --remove-chain ipv4 filter rtpengine
+			firewall-cmd --reload
+		else
+			iptables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
+			if [[ $CUR_IP6 == 1 ]]
+			then
+    				ip6tables -D rtpengine -p udp -j RTPENGINE --id $CUR_TABLE
+  			fi
+			iptables -t filter -D INPUT -j rtpengine
+			iptables -X rtpengine
+		fi
+		rmmod xt_RTPENGINE
 		rm -f $cachefile	
 	fi
  


### PR DESCRIPTION
Now works with firewalld - creates a permanent chain called INPUT_prefilter
which is then called before the conntrack stuff in the INPUT tables. We then create
our temporary rtpengine chain by linking into that.
Also brought in some of the IPv6 stuff from the standard Centos init script