### PR TITLE
add macros that get older versions of glib to compile if gcc is being…

### DIFF
--- a/daemon/aux.h
+++ b/daemon/aux.h
@@ -20,6 +20,28 @@
 #include "compat.h"
 #include <openssl/rand.h>
 
+#if !(GLIB_CHECK_VERSION(2,30,0))
+#define g_atomic_int_and(atomic, val) \
+(G_GNUC_EXTENSION ({                                                          \
+G_STATIC_ASSERT (sizeof *(atomic) == sizeof (gint));                     \
+(void) (0 ? *(atomic) ^ (val) : 0);                                      \
+(guint) __sync_fetch_and_and ((atomic), (val));                          \
+}))
+#define g_atomic_int_or(atomic, val) \
+(G_GNUC_EXTENSION ({                                                          \
+G_STATIC_ASSERT (sizeof *(atomic) == sizeof (gint));                     \
+(void) (0 ? *(atomic) ^ (val) : 0);                                      \
+(guint) __sync_fetch_and_or ((atomic), (val));                           \
+}))
+#define g_atomic_pointer_add(atomic, val) \
+(G_GNUC_EXTENSION ({                                                          \
+    G_STATIC_ASSERT (sizeof *(atomic) == sizeof (gpointer));            \
+    (void) (0 ? (gpointer) *(atomic) : 0);                              \
+    (void) (0 ? (val) ^ (val) : 0);                                     \
+    (gssize) __sync_fetch_and_add ((atomic), (val));                    \
+}))
+#endif
+
 #if 0 && defined(__DEBUG)
 #define __THREAD_DEBUG 1
 #endif


### PR DESCRIPTION
credit to paulandrewhughes

In glib 2.30 the missing functions are defined in macros when gcc is the compiler:
Adding these definitions as follows after the #include statements in aux.h allows code to compile on centos6.7 and other platforms that lack glib 2.30 but have the required gcc extensions.