### PR TITLE
Solve packet errors due to payload type

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1686,7 +1686,7 @@ fail:
 	return -1;
 }
 
-static void __payload_type_free(void *p) {
+void __payload_type_free(void *p) {
 	g_slice_free1(sizeof(struct rtp_payload_type), p);
 }
 
@@ -1988,7 +1988,7 @@ static int __init_stream(struct packet_stream *ps) {
 	return 0;
 }
 
-static void __rtp_stats_update(GHashTable *dst, GHashTable *src) {
+void __rtp_stats_update(GHashTable *dst, GHashTable *src) {
 	struct rtp_stats *rs;
 	struct rtp_payload_type *pt;
 	GList *values, *l;

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -529,6 +529,9 @@ struct interface_address *get_any_interface_address(struct local_interface *lif,
 const struct transport_protocol *transport_protocol(const str *s);
 void add_total_calls_duration_in_interval(struct callmaster *cm, struct timeval *interval_tv);
 
+void __payload_type_free(void *p);
+void __rtp_stats_update(GHashTable *dst, GHashTable *src);
+
 
 INLINE void *call_malloc(struct call *c, size_t l) {
 	void *ret;


### PR DESCRIPTION
The payload types are not saved and retrieved from redis. Used a hash to
store the payload types in the form (0, payload_value0), (1, payload_value1)
for every media.