### PR TITLE
Fix cli only starts if LISTEN_TCP is present in config

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -602,7 +602,7 @@ no_kernel:
 	}
 
 	cl = NULL;
-	if (tcp_listen_ep.port) {
+	if (cli_listen_ep.port) {
 		interfaces_exclude_port(cli_listen_ep.port);
 	    cl = cli_new(ctx->p, &cli_listen_ep, ctx->m);
 	    if (!cl)


### PR DESCRIPTION
There seems to be a typo in main.c which prevents cli functionality to be started unless LISTEN_TCP is present in config.