### PR TITLE
Return error when no free ports are available

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1595,7 +1595,8 @@ init:
 	return 0;
 
 error:
-	ilog(LOG_ERR, "Error allocating media ports");
+	ilog(LOG_ERR, "Error allocating media ports, destroying call %.*s", call->callid.len, call->callid.s);
+	call_destroy(call);
 	return -1;
 }
 
@@ -2482,7 +2483,7 @@ int call_delete_branch(struct callmaster *m, const str *callid, const str *branc
 
 	c = call_get(callid, m);
 	if (!c) {
-		ilog(LOG_INFO, "Call-ID to delete not found");
+		ilog(LOG_INFO, "Call-ID "STR_FORMAT" to delete not found", STR_FMT(callid));
 		goto err;
 	}
 

--- a/daemon/control_ng.c
+++ b/daemon/control_ng.c
@@ -127,7 +127,7 @@ static void control_ng_incoming(struct obj *obj, str *buf, const endpoint_t *sin
 	bencode_dictionary_get_str(dict, "call-id", &callid);
 	log_info_str(&callid);
 
-	ilog(LOG_INFO, "Received command '"STR_FORMAT"' from %s", STR_FMT(&cmd), addr);
+	ilog(LOG_INFO, "Received command '"STR_FORMAT"' from %s for call "STR_FORMAT"", STR_FMT(&cmd), addr, STR_FMT(&callid));
 
 	if (get_log_level() >= LOG_DEBUG) {
 		log_str = g_string_sized_new(256);


### PR DESCRIPTION
Free the used structures and sockets and  return -1 if there are no free ports on _all_ local interfaces of the given logical interface.

Suppose the case of audio+video; suppose 4 ports are available, so bridgeports are allocated for the audio stream; now suppose next 4 ports are not available anymore(for video). In this case of free ports failure one needs also to free the audio sockets also. In order to do this, I called call_destroy() upon get_consecutive_ports() failure.

The other approach would have been to implement functions that iterate through monologue's medias and free the sockets, but I've found call_destroy() more clean.