### PR TITLE
Round Robin logical interface selection based on direction attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,25 @@ Optionally included keys are:
 	However, this mechanism for selecting the address family is now obsolete
 	and the `address family` dictionary key should be used instead.
 
+	A direction keyword is *round-robin-streams*. If this is received, a round robin algorithm runs for
+	choosing the logical interface for the current stream(e.g. audio, video).
+	The algorithm checks that all local interfaces of the tried logical interface have free ports for a
+	stream (e.g. 4). If a logical interface fails the check, the next one is tried. If there is no logical
+	interface found with this property, it fallbacks to the default behaviour (e.g. return first logical
+	interface in --interface list even if no free ports are available). The attribute is ignored for
+	answers() because the logical interface was already selected at offers().
+	Naming an interface "round-robin-streams" and trying to select it using direction will run the
+	above algorithm.
+
+	Round robin for both legs of the stream:
+		{ ..., "direction": [ "round-robin-streams", "round-robin-streams" ], ... } 
+
+	Round robin for first leg and and select "pub" for the second leg of the stream:
+		{ ..., "direction": [ "round-robin-streams", "pub" ], ... }
+
+	Round robin for first leg and and default behaviour for the second leg of the stream:
+		{ ..., "direction": [ "round-robin-streams" ], ... }
+
 * `received from`
 
 	Contains a list of exactly two elements. The first element denotes the address family and the second


### PR DESCRIPTION
If **direction=round-robin-calls** attribute is received, a round robin algorithm runs for choosing the logical interface of the call media. The algorithm checks that _all local interfaces_ of the tried logical interface have PORTS_PER_STREAM=4 free ports. If a logical interface fails the check, the next one is tried. If there is _no_ logical interface found with this property, it fallbacks to the default behaviour (e.g. return NULL and on the subsequent call and eventually first logical interface in INTERFACES is returned even if no ports are available). The attribute is ignored for answers() because the logical interface was already selected at offers().

In the current implementation, in the case of audio+video streams, the audio stream(4 ports) might be assigned on log1 and the video stream(4 ports) on log2. This is because I tried to keep the changes as simple as I could. If one wants forcing audio + video on the same log1, the header of the functions must be modified to also accept the number of ports to be checked as free(e.g. 8 ports) and decreasing them while the streams get allocated(e.g. check for 8 ports for audio stream, then check for another remaining 4 ports for the video stream).

The purpose of the round robin is to load balance between a list of logical interfaces given.