### PR TITLE
Avoid deadlocks when the port limit is reached

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1595,9 +1595,8 @@ init:
 	return 0;
 
 error:
-	ilog(LOG_ERR, "Error allocating media ports, destroying call");
-	call_destroy(call);
-	return -1;
+	ilog(LOG_ERR, "Error allocating media ports");
+	return ERROR_NO_FREE_PORTS;
 }
 
 static void timeval_totalstats_average_add(struct totalstats *s, const struct timeval *add) {

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -78,6 +78,8 @@ enum call_stream_state {
 #include "rtp.h"
 
 
+#define ERROR_NO_FREE_PORTS	-100
+
 
 #define MAX_RTP_PACKET_SIZE	8192
 #define RTP_BUFFER_HEAD_ROOM	128

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -713,6 +713,12 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	gettimeofday(&(monologue->started), NULL);
 
 	errstr = "Error rewriting SDP";
+
+	if (ret == ERROR_NO_FREE_PORTS) {
+		ilog(LOG_ERR, "Destroying call");
+		call_destroy(call);
+	}
+
 	if (ret)
 		goto out;
 


### PR DESCRIPTION
Related to 3911374 .

One solution is to schedule it for deletion with delay 0 inside
monologue_offer_answer() (e.g. call->deleted = poller_now). After testing, I've
seen this has no effect (partially established calls keep the bounded ports).

Other solution is to call_destroy() outside monologue_offer_answer(),
after the call lock is released. This is the case here.