### PR TITLE
Round Robin logical interface selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,25 @@ Optionally included keys are:
 	However, this mechanism for selecting the address family is now obsolete
 	and the `address family` dictionary key should be used instead.
 
+	A direction keyword is *round-robin-calls*. If this is received, a round robin algorithm runs for
+	choosing the logical interface for the current stream(e.g. audio, video).
+	The algorithm checks that all local interfaces of the tried logical interface have free ports for
+	call streams. If a logical interface fails the check, the next one is tried. If there is no logical
+	interface found with this property, it fallbacks to the default behaviour (e.g. return first logical
+	interface in --interface list even if no free ports are available). The attribute is ignored for
+	answers() because the logical interface was already selected at offers().
+	Naming an interface "round-robin-calls" and trying to select it using direction will
+	__run the above algorithm__!
+
+	Round robin for both legs of the stream:
+		{ ..., "direction": [ "round-robin-calls", "round-robin-calls" ], ... } 
+
+	Round robin for first leg and and select "pub" for the second leg of the stream:
+		{ ..., "direction": [ "round-robin-calls", "pub" ], ... }
+
+	Round robin for first leg and and default behaviour for the second leg of the stream:
+		{ ..., "direction": [ "round-robin-calls" ], ... }
+
 * `received from`
 
 	Contains a list of exactly two elements. The first element denotes the address family and the second

--- a/daemon/aux.h
+++ b/daemon/aux.h
@@ -60,7 +60,8 @@ G_STATIC_ASSERT (sizeof *(atomic) == sizeof (gint));                     \
 #define NUM_THREAD_BUFS		8
 
 
-
+#define ALGORITHM_DEFAULT		""
+#define ALGORITHM_ROUND_ROBIN_CALLS	"round-robin-calls"
 
 /*** GLOBALS ***/
 

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -79,7 +79,7 @@ enum call_stream_state {
 
 
 #define ERROR_NO_FREE_PORTS	-100
-
+#define ERROR_NO_FREE_LOGS	-101
 
 #define MAX_RTP_PACKET_SIZE	8192
 #define RTP_BUFFER_HEAD_ROOM	128

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -714,7 +714,7 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 
 	errstr = "Error rewriting SDP";
 
-	if (ret == ERROR_NO_FREE_PORTS) {
+	if (ret == ERROR_NO_FREE_PORTS || ret == ERROR_NO_FREE_LOGS) {
 		ilog(LOG_ERR, "Destroying call");
 		call_destroy(call);
 	}

--- a/daemon/media_socket.h
+++ b/daemon/media_socket.h
@@ -26,6 +26,7 @@ struct logical_intf {
 struct port_pool {
 	BIT_ARRAY_DECLARE(ports_used, 0x10000);
 	volatile unsigned int		last_used;
+	volatile unsigned int		free_ports;
 
 	unsigned int			min, max;
 };
@@ -67,7 +68,7 @@ struct stream_fd {
 
 void interfaces_init(GQueue *interfaces);
 
-struct logical_intf *get_logical_interface(const str *name, sockfamily_t *fam);
+struct logical_intf *get_logical_interface(const str *name, sockfamily_t *fam, int num_ports);
 struct local_intf *get_interface_address(const struct logical_intf *lif, sockfamily_t *fam);
 struct local_intf *get_any_interface_address(const struct logical_intf *lif, sockfamily_t *fam);
 void interfaces_exclude_port(unsigned int port);

--- a/daemon/socket.c
+++ b/daemon/socket.c
@@ -502,14 +502,15 @@ fail:
 	return -1;
 }
 
-void close_socket(socket_t *r) {
+int close_socket(socket_t *r) {
 	if (!r || r->fd == -1) {
 		__C_DBG("close() syscall not called, fd=%d", r->fd);
-		return;
+		return -1;
 	}
 
 	if (close(r->fd) != 0) {
 		__C_DBG("close() syscall fail, fd=%d", r->fd);
+		return -1;
 	}
 
 	__C_DBG("close() syscall success, fd=%d", r->fd);
@@ -517,6 +518,8 @@ void close_socket(socket_t *r) {
 	r->fd = -1;
 	ZERO(r->local);
 	ZERO(r->remote);
+
+	return 0;
 }
 
 

--- a/daemon/socket.h
+++ b/daemon/socket.h
@@ -175,7 +175,7 @@ void socket_init(void);
 int open_socket(socket_t *r, int type, unsigned int port, const sockaddr_t *);
 int connect_socket(socket_t *r, int type, const endpoint_t *ep);
 int connect_socket_nb(socket_t *r, int type, const endpoint_t *ep);
-void close_socket(socket_t *r);
+int close_socket(socket_t *r);
 
 sockfamily_t *get_socket_family_rfc(const str *s);
 sockfamily_t *__get_socket_family_enum(enum socket_families);


### PR DESCRIPTION
Improvements since last time:
- maintain and update volatile _free_ports_ while binding and releasing ports => fast deciding if free ports available
- no hard coded #defines; the ports are calculated based on the stream_params that have "round-robin-calls" direction
- take into consideration the media call legs based on given kamailio direction (e.g. direction=round-robin-calls direction=pub1)
