### PR TITLE
Avoid cdr buffer overlows. Add some ICE NULL checks

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2795,6 +2795,8 @@ struct timeval add_ongoing_calls_dur_in_interval(struct callmaster *m,
 	return res;
 }
 
+#define CDRBUFREMAINDER cdrbufend-cdrbufcur
+
 /* called lock-free, but must hold a reference to the call */
 void call_destroy(struct call *c) {
 	struct callmaster *m = c->callmaster;
@@ -2810,7 +2812,9 @@ void call_destroy(struct call *c) {
 	static const int CDRBUFLENGTH = 4096*2;
 	char cdrbuffer[CDRBUFLENGTH];
 	char* cdrbufcur = cdrbuffer;
+	char* cdrbufend = cdrbuffer+CDRBUFLENGTH-1;
 	int cdrlinecnt = 0;
+	int printlen=0;
 	int found = 0;
 	const struct rtp_payload_type *rtp_pt;
 
@@ -2842,10 +2846,14 @@ void call_destroy(struct call *c) {
 
 	/* CDRs and statistics */
 	if (_log_facility_cdr) {
-		cdrbufcur += sprintf(cdrbufcur,"ci=%s, ",c->callid.s);
-		cdrbufcur += sprintf(cdrbufcur,"created_from=%s, ", c->created_from);
-		cdrbufcur += sprintf(cdrbufcur,"last_signal=%llu, ", (unsigned long long)c->last_signal);
-		cdrbufcur += sprintf(cdrbufcur,"tos=%u, ", (unsigned int)c->tos);
+		printlen = snprintf(cdrbufcur,CDRBUFREMAINDER,"ci=%s, ",c->callid.s);
+		ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
+		printlen = snprintf(cdrbufcur,CDRBUFREMAINDER,"created_from=%s, ", c->created_from);
+		ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
+		printlen = snprintf(cdrbufcur,CDRBUFREMAINDER,"last_signal=%llu, ", (unsigned long long)c->last_signal);
+		ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
+		printlen = snprintf(cdrbufcur,CDRBUFREMAINDER,"tos=%u, ", (unsigned int)c->tos);
+		ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 	}
 
 	for (l = c->monologues; l; l = l->next) {
@@ -2859,20 +2867,22 @@ void call_destroy(struct call *c) {
 		timeval_subtract(&tim_result_duration,&ml->terminated,&ml->started);
 
 		if (_log_facility_cdr) {
-		    cdrbufcur += sprintf(cdrbufcur, "ml%i_start_time=%ld.%06lu, "
-		            "ml%i_end_time=%ld.%06ld, "
-		            "ml%i_duration=%ld.%06ld, "
-		            "ml%i_termination=%s, "
-		            "ml%i_local_tag=%s, "
-		            "ml%i_local_tag_type=%s, "
-		            "ml%i_remote_tag=%s, ",
-		            cdrlinecnt, ml->started.tv_sec, ml->started.tv_usec,
-		            cdrlinecnt, ml->terminated.tv_sec, ml->terminated.tv_usec,
-		            cdrlinecnt, tim_result_duration.tv_sec, tim_result_duration.tv_usec,
-		            cdrlinecnt, get_term_reason_text(ml->term_reason),
-		            cdrlinecnt, ml->tag.s,
-		            cdrlinecnt, get_tag_type_text(ml->tagtype),
-		            cdrlinecnt, ml->active_dialogue ? ml->active_dialogue->tag.s : "(none)");
+			printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
+				"ml%i_start_time=%ld.%06lu, "
+				"ml%i_end_time=%ld.%06ld, "
+				"ml%i_duration=%ld.%06ld, "
+				"ml%i_termination=%s, "
+				"ml%i_local_tag=%s, "
+				"ml%i_local_tag_type=%s, "
+				"ml%i_remote_tag=%s, ",
+				cdrlinecnt, ml->started.tv_sec, ml->started.tv_usec,
+				cdrlinecnt, ml->terminated.tv_sec, ml->terminated.tv_usec,
+				cdrlinecnt, tim_result_duration.tv_sec, tim_result_duration.tv_usec,
+				cdrlinecnt, get_term_reason_text(ml->term_reason),
+				cdrlinecnt, ml->tag.s,
+				cdrlinecnt, get_tag_type_text(ml->tagtype),
+				cdrlinecnt, ml->active_dialogue ? ml->active_dialogue->tag.s : "(none)");
+			ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 		}
 
 		ilog(LOG_INFO, "--- Tag '"STR_FORMAT"', created "
@@ -2905,10 +2915,11 @@ void call_destroy(struct call *c) {
 
 			/* add PayloadType(codec) info in CDR logging */
 			if (_log_facility_cdr && rtp_pt) {
-				cdrbufcur += sprintf(cdrbufcur,
-					"payload_type=%u, ", rtp_pt->payload_type);
+				printlen = snprintf(cdrbufcur, CDRBUFREMAINDER, "payload_type=%u, ", rtp_pt->payload_type);
+				ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 			} else if (_log_facility_cdr && !rtp_pt) {
-				cdrbufcur += sprintf(cdrbufcur, "payload_type=unknown, ");
+				printlen = snprintf(cdrbufcur, CDRBUFREMAINDER, "payload_type=unknown, ");
+				ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 			}
 
 			for (o = md->streams.head; o; o = o->next) {
@@ -2923,82 +2934,84 @@ void call_destroy(struct call *c) {
 				    const char* protocol = (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? "rtcp" : "rtp";
 
 				    if(!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) {
-					    cdrbufcur += sprintf(cdrbufcur,
-					            "ml%i_midx%u_%s_endpoint_ip=%s, "
-					            "ml%i_midx%u_%s_endpoint_port=%u, "
-					            "ml%i_midx%u_%s_local_relay_port=%u, "
-					            "ml%i_midx%u_%s_relayed_packets="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_bytes="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_errors="UINT64F", "
-					            "ml%i_midx%u_%s_last_packet="UINT64F", "
-				    			"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
-					            cdrlinecnt, md->index, protocol, addr,
-					            cdrlinecnt, md->index, protocol, ps->endpoint.port,
-					            cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.packets),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.bytes),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.errors),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->last_packet),
-								cdrlinecnt, md->index, protocol,
-							ps->stats.in_tos_tclass);
+					printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
+						"ml%i_midx%u_%s_endpoint_ip=%s, "
+						"ml%i_midx%u_%s_endpoint_port=%u, "
+						"ml%i_midx%u_%s_local_relay_port=%u, "
+						"ml%i_midx%u_%s_relayed_packets="UINT64F", "
+						"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
+						"ml%i_midx%u_%s_relayed_errors="UINT64F", "
+						"ml%i_midx%u_%s_last_packet="UINT64F", "
+						"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
+						cdrlinecnt, md->index, protocol, addr,
+						cdrlinecnt, md->index, protocol, ps->endpoint.port,
+						cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.packets),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.bytes),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.errors),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->last_packet),
+						cdrlinecnt, md->index, protocol,
+						ps->stats.in_tos_tclass);
+					ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 				    } else {
 #if (RE_HAS_MEASUREDELAY)
-				    	cdrbufcur += sprintf(cdrbufcur,
-					            "ml%i_midx%u_%s_endpoint_ip=%s, "
-					            "ml%i_midx%u_%s_endpoint_port=%u, "
-					            "ml%i_midx%u_%s_local_relay_port=%u, "
-					            "ml%i_midx%u_%s_relayed_packets="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_bytes="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_errors="UINT64F", "
-					            "ml%i_midx%u_%s_last_packet="UINT64F", "
-						    "ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", "
-						    "ml%i_midx%u_%s_delay_min=%.9f, "
-						    "ml%i_midx%u_%s_delay_avg=%.9f, "
-						    "ml%i_midx%u_%s_delay_max=%.9f, ",
-					            cdrlinecnt, md->index, protocol, addr,
-					            cdrlinecnt, md->index, protocol, ps->endpoint.port,
-					            cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.packets),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.bytes),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.errors),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->last_packet),
-								cdrlinecnt, md->index, protocol,
-							ps->stats.in_tos_tclass,
-								cdrlinecnt, md->index, protocol, (double) ps->stats.delay_min / 1000000,
-								cdrlinecnt, md->index, protocol, (double) ps->stats.delay_avg / 1000000,
-								cdrlinecnt, md->index, protocol, (double) ps->stats.delay_max / 1000000);
+				    	printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
+						"ml%i_midx%u_%s_endpoint_ip=%s, "
+						"ml%i_midx%u_%s_endpoint_port=%u, "
+						"ml%i_midx%u_%s_local_relay_port=%u, "
+						"ml%i_midx%u_%s_relayed_packets="UINT64F", "
+						"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
+						"ml%i_midx%u_%s_relayed_errors="UINT64F", "
+						"ml%i_midx%u_%s_last_packet="UINT64F", "
+						"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", "
+						"ml%i_midx%u_%s_delay_min=%.9f, "
+						"ml%i_midx%u_%s_delay_avg=%.9f, "
+						"ml%i_midx%u_%s_delay_max=%.9f, ",
+						cdrlinecnt, md->index, protocol, addr,
+						cdrlinecnt, md->index, protocol, ps->endpoint.port,
+						cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.packets),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.bytes),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.errors),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->last_packet),
+						cdrlinecnt, md->index, protocol,
+						ps->stats.in_tos_tclass,
+						cdrlinecnt, md->index, protocol, (double) ps->stats.delay_min / 1000000,
+						cdrlinecnt, md->index, protocol, (double) ps->stats.delay_avg / 1000000,
+						cdrlinecnt, md->index, protocol, (double) ps->stats.delay_max / 1000000);
+					ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 #else
-					    cdrbufcur += sprintf(cdrbufcur,
-					            "ml%i_midx%u_%s_endpoint_ip=%s, "
-					            "ml%i_midx%u_%s_endpoint_port=%u, "
-					            "ml%i_midx%u_%s_local_relay_port=%u, "
-					            "ml%i_midx%u_%s_relayed_packets="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_bytes="UINT64F", "
-					            "ml%i_midx%u_%s_relayed_errors="UINT64F", "
-					            "ml%i_midx%u_%s_last_packet="UINT64F", "
-				    			"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
-					            cdrlinecnt, md->index, protocol, addr,
-					            cdrlinecnt, md->index, protocol, ps->endpoint.port,
-					            cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.packets),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.bytes),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->stats.errors),
-					            cdrlinecnt, md->index, protocol,
-						    atomic64_get(&ps->last_packet),
-								cdrlinecnt, md->index, protocol,
-							ps->stats.in_tos_tclass);
-
+					printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
+						"ml%i_midx%u_%s_endpoint_ip=%s, "
+						"ml%i_midx%u_%s_endpoint_port=%u, "
+						"ml%i_midx%u_%s_local_relay_port=%u, "
+						"ml%i_midx%u_%s_relayed_packets="UINT64F", "
+						"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
+						"ml%i_midx%u_%s_relayed_errors="UINT64F", "
+						"ml%i_midx%u_%s_last_packet="UINT64F", "
+						"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
+						cdrlinecnt, md->index, protocol, addr,
+						cdrlinecnt, md->index, protocol, ps->endpoint.port,
+						cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.packets),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.bytes),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->stats.errors),
+						cdrlinecnt, md->index, protocol,
+						atomic64_get(&ps->last_packet),
+						cdrlinecnt, md->index, protocol,
+						ps->stats.in_tos_tclass);
+					ADJUSTLEN(printlen,cdrbufend,cdrbufcur);
 #endif
 				    }
 				}

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -18,6 +18,16 @@
 #include "control_ng.h"
 #include "aux.h"
 
+#define TRUNCATED " ... Output truncated. Increase Output Buffer ...                                    \n"
+
+#define truncate_output(x) strcpy(x - strlen(TRUNCATED) - 1, TRUNCATED)
+
+#define ADJUSTLEN(printlen,outbufend,replybuffer) do { \
+               replybuffer += (printlen>=outbufend-replybuffer)?outbufend-replybuffer:printlen; \
+               if (replybuffer == outbufend) \
+                       truncate_output(replybuffer); \
+       } while (0);
+
 enum termination_reason {
 	UNKNOWN=0,
 	REGULAR=1,

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -16,16 +16,6 @@
 
 #include "rtpengine_config.h"
 
-static const char* TRUNCATED = "    ... Output truncated. Increase Output Buffer ...\n";
-
-#define truncate_output(x) strcpy(x - strlen(TRUNCATED) - 1, TRUNCATED)
-
-#define ADJUSTLEN(printlen,outbuflen,replybuffer) do { \
-               replybuffer += (printlen>=outbufend-replybuffer)?outbufend-replybuffer:printlen; \
-               if (replybuffer == outbufend) \
-                       truncate_output(replybuffer); \
-       } while (0);
-
 static void cli_incoming_list_totals(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
 	int printlen=0;
 	struct timeval avg, calls_dur_iv;

--- a/daemon/ice.c
+++ b/daemon/ice.c
@@ -471,9 +471,18 @@ static void ice_candidate_pairs_free(GQueue *q) {
 
 /* call must be locked */
 void ice_shutdown(struct ice_agent **agp) {
-	struct ice_agent *ag = *agp;
-	if (!ag)
+	struct ice_agent *ag;
+
+	if (!agp) {
+		ilog(LOG_ERR, "ice agp is NULL");
+		return ;
+	}
+
+	ag = *agp;
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
 		return;
+	}
 
 	__agent_deschedule(ag);
 
@@ -481,6 +490,11 @@ void ice_shutdown(struct ice_agent **agp) {
 	obj_put(ag);
 }
 static void __ice_agent_free_components(struct ice_agent *ag) {
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return;
+	}
+
 	g_queue_clear(&ag->triggered);
 	g_hash_table_destroy(ag->candidate_hash);
 	g_hash_table_destroy(ag->pair_hash);
@@ -496,6 +510,11 @@ static void __ice_agent_free_components(struct ice_agent *ag) {
 }
 static void __ice_agent_free(void *p) {
 	struct ice_agent *ag = p;
+
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return;
+	}
 
 	__DBG("freeing ice_agent");
 
@@ -516,6 +535,11 @@ static void __agent_schedule(struct ice_agent *ag, unsigned long usec) {
 static void __agent_schedule_abs(struct ice_agent *ag, const struct timeval *tv) {
 	struct timeval nxt;
 	long long diff;
+
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return;
+	}
 
 	nxt = *tv;
 
@@ -538,6 +562,12 @@ nope:
 }
 static void __agent_deschedule(struct ice_agent *ag) {
 	int ret;
+
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return;
+	}
+
 	mutex_lock(&ice_agents_timers_lock);
 	if (!ag->next_check.tv_sec)
 		goto nope; /* already descheduled */
@@ -697,6 +727,11 @@ static void __do_ice_checks(struct ice_agent *ag) {
 	GQueue retransmits = G_QUEUE_INIT;
 	struct timeval next_run = {0,0};
 	int have_more = 0;
+
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return;
+	}
 
 	if (!ag->pwd[0].s)
 		return;
@@ -1000,6 +1035,11 @@ static int __check_valid(struct ice_agent *ag) {
 	GQueue all_compos;
 	struct ice_candidate_pair *pair;
 	struct interface_address *ifa;
+
+	if (!ag) {
+		ilog(LOG_ERR, "ice ag is NULL");
+		return 0;
+	}
 
 	__get_complete_valid_pairs(&all_compos, ag);
 


### PR DESCRIPTION
sprintf might lead to overflows.
Encountered and ice_shutdown() segfault when call was destroyed (suppose cdr buffer overflow caused it, corrupting pointer values).