### PR TITLE
Allow non-root users to run rtpengine in kernel mode

### DIFF
--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -180,7 +180,12 @@ start() {
 	then
 		echo "Loading module for in-kernel packet forwarding"
 		rmmod xt_RTPENGINE 2> /dev/null
-		modprobe xt_RTPENGINE
+		if [[ -n "$RE_USER" ]]
+		then
+			modprobe xt_RTPENGINE set_proc_id=1 proc_uid=$(id $RE_USER -u) proc_gid=$(id $RE_USER -g)
+		else
+			modprobe xt_RTPENGINE
+		fi
 		temp=`firewall-cmd --state 2>/dev/null`
 		if [[ $? == 0 ]]
 		then
@@ -212,7 +217,12 @@ CUR_TABLE=$TABLE
 EOF
 	fi
         echo -n $"Starting $prog: "
-        daemon --pidfile=${pidfile} $rtpengine $OPTS
+	if [[ -n "$RE_USER" ]]
+	then
+		daemon --user $RE_USER --pidfile=${pidfile} $rtpengine $OPTS
+	else
+		daemon --pidfile=${pidfile} $rtpengine $OPTS
+	fi
         RETVAL=$?
         echo
         [ $RETVAL = 0 ] && touch ${lockfile}

--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -182,7 +182,13 @@ start() {
 		rmmod xt_RTPENGINE 2> /dev/null
 		if [[ -n "$RE_USER" ]]
 		then
-			modprobe xt_RTPENGINE set_proc_id=1 proc_uid=$(id $RE_USER -u) proc_gid=$(id $RE_USER -g)
+			if [[ -n "$RE_GROUP" ]]
+			then
+				proc_gid=$(grep ^$RE_GROUP: /etc/group | cut -f3 -d:)
+			else
+				proc_gid=$(id $RE_USER -g)
+			fi
+			modprobe xt_RTPENGINE proc_uid=$(id $RE_USER -u) proc_gid=$proc_gid
 		else
 			modprobe xt_RTPENGINE
 		fi

--- a/el/rtpengine.sysconfig
+++ b/el/rtpengine.sysconfig
@@ -42,3 +42,5 @@ LISTEN_UDP=127.0.0.1:2222	# IP address and port combination for UDP
 #B2B_URL=http://127.0.0.1:8080/xmlrpc
 
 #RE_USER=rtpengine	# Run rtpengine as this specific user
+
+#RE_GROUP=rtpengine	# allow this group to control rtpengine in kernel mode

--- a/el/rtpengine.sysconfig
+++ b/el/rtpengine.sysconfig
@@ -40,3 +40,5 @@ LISTEN_UDP=127.0.0.1:2222	# IP address and port combination for UDP
 #REDIS=127.0.0.1:6379
 #REDIS_DB=0
 #B2B_URL=http://127.0.0.1:8080/xmlrpc
+
+#RE_USER=rtpengine	# Run rtpengine as this specific user

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -82,10 +82,6 @@ struct rtp_parsed;
 struct re_crypto_context;
 
 
-bool set_proc_id = true;
-module_param(set_proc_id, bool, 0);
-MODULE_PARM_DESC(set_proc_id, "set specific user and group ids for the rtpengine procfs tree");
-
 kuid_t proc_kuid;
 uint proc_uid = 0;
 module_param(proc_uid, uint, 0);
@@ -410,40 +406,35 @@ static int table_create_proc(struct rtpengine_table *t, u_int32_t id) {
 	if (!t->proc)
 		return -1;
 
-	if (set_proc_id)
-		proc_set_user(t->proc, proc_kuid, proc_kgid);
+	proc_set_user(t->proc, proc_kuid, proc_kgid);
 
 	t->status = proc_create_data("status", S_IFREG | S_IRUGO, t->proc, &proc_status_ops,
 		(void *) (unsigned long) id);
 	if (!t->status)
 		return -1;
 
-	if (set_proc_id)
-		proc_set_user(t->status, proc_kuid, proc_kgid);
+	proc_set_user(t->status, proc_kuid, proc_kgid);
 
 	t->control = proc_create_data("control", S_IFREG | S_IWUSR | S_IWGRP, t->proc,
 			&proc_control_ops, (void *) (unsigned long) id);
 	if (!t->control)
 		return -1;
 
-	if (set_proc_id)
-		proc_set_user(t->control, proc_kuid, proc_kgid);
+	proc_set_user(t->control, proc_kuid, proc_kgid);
 
 	t->list = proc_create_data("list", S_IFREG | S_IRUGO, t->proc,
 			&proc_list_ops, (void *) (unsigned long) id);
 	if (!t->list)
 		return -1;
 
-	if (set_proc_id)
-		proc_set_user(t->list, proc_kuid, proc_kgid);
+	proc_set_user(t->list, proc_kuid, proc_kgid);
 
 	t->blist = proc_create_data("blist", S_IFREG | S_IRUGO, t->proc,
 			&proc_blist_ops, (void *) (unsigned long) id);
 	if (!t->blist)
 		return -1;
 
-	if (set_proc_id)
-		proc_set_user(t->blist, proc_kuid, proc_kgid);
+	proc_set_user(t->blist, proc_kuid, proc_kgid);
 
 	return 0;
 }
@@ -2568,11 +2559,9 @@ static int __init init(void) {
 	const char *err;
 
 	printk(KERN_NOTICE "Registering xt_RTPENGINE module - version %s\n", RTPENGINE_VERSION);
-	if (set_proc_id) {
-		printk(KERN_NOTICE "using uid %u, gid %d\n", proc_uid, proc_gid);
-		proc_kuid = KUIDT_INIT(proc_uid);
-		proc_kgid = KGIDT_INIT(proc_gid);
-	}
+	printk(KERN_DEBUG "using uid %u, gid %d\n", proc_uid, proc_gid);
+	proc_kuid = KUIDT_INIT(proc_uid);
+	proc_kgid = KGIDT_INIT(proc_gid);
 
 	rwlock_init(&table_lock);
 
@@ -2582,8 +2571,7 @@ static int __init init(void) {
 	if (!my_proc_root)
 		goto fail;
 
-	if (set_proc_id)
-		proc_set_user(my_proc_root, proc_kuid, proc_kgid);
+	proc_set_user(my_proc_root, proc_kuid, proc_kgid);
 	/* my_proc_root->owner = THIS_MODULE; */
 
 	proc_control = proc_create("control", S_IFREG | S_IWUSR | S_IWGRP, my_proc_root,
@@ -2591,15 +2579,13 @@ static int __init init(void) {
 	if (!proc_control)
 		goto fail;
 
-	if (set_proc_id)
-		proc_set_user(proc_control, proc_kuid, proc_kgid);
+	proc_set_user(proc_control, proc_kuid, proc_kgid);
 
 	proc_list = proc_create("list", S_IFREG | S_IRUGO, my_proc_root, &proc_main_list_ops);
 	if (!proc_list)
 		goto fail;
 
-	if (set_proc_id)
-		proc_set_user(proc_list, proc_kuid, proc_kgid);
+	proc_set_user(proc_list, proc_kuid, proc_kgid);
 
 	err = "could not register xtables target";
 	ret = xt_register_targets(xt_rtpengine_regs, ARRAY_SIZE(xt_rtpengine_regs));

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -82,6 +82,20 @@ struct rtp_parsed;
 struct re_crypto_context;
 
 
+bool set_proc_id = true;
+module_param(set_proc_id, bool, 0);
+MODULE_PARM_DESC(set_proc_id, "set specific user and group ids for the rtpengine procfs tree");
+
+kuid_t proc_kuid;
+uint proc_uid = 0;
+module_param(proc_uid, uint, 0);
+MODULE_PARM_DESC(proc_uid, "rtpengine procfs tree user id");
+
+
+kgid_t proc_kgid;
+uint proc_gid = 0;
+module_param(proc_gid, uint, 0);
+MODULE_PARM_DESC(proc_gid, "rtpengine procfs tree group id");
 
 
 static struct proc_dir_entry *my_proc_root;
@@ -396,25 +410,40 @@ static int table_create_proc(struct rtpengine_table *t, u_int32_t id) {
 	if (!t->proc)
 		return -1;
 
+	if (set_proc_id)
+		proc_set_user(t->proc, proc_kuid, proc_kgid);
+
 	t->status = proc_create_data("status", S_IFREG | S_IRUGO, t->proc, &proc_status_ops,
 		(void *) (unsigned long) id);
 	if (!t->status)
 		return -1;
+
+	if (set_proc_id)
+		proc_set_user(t->status, proc_kuid, proc_kgid);
 
 	t->control = proc_create_data("control", S_IFREG | S_IWUSR | S_IWGRP, t->proc,
 			&proc_control_ops, (void *) (unsigned long) id);
 	if (!t->control)
 		return -1;
 
+	if (set_proc_id)
+		proc_set_user(t->control, proc_kuid, proc_kgid);
+
 	t->list = proc_create_data("list", S_IFREG | S_IRUGO, t->proc,
 			&proc_list_ops, (void *) (unsigned long) id);
 	if (!t->list)
 		return -1;
 
+	if (set_proc_id)
+		proc_set_user(t->list, proc_kuid, proc_kgid);
+
 	t->blist = proc_create_data("blist", S_IFREG | S_IRUGO, t->proc,
 			&proc_blist_ops, (void *) (unsigned long) id);
 	if (!t->blist)
 		return -1;
+
+	if (set_proc_id)
+		proc_set_user(t->blist, proc_kuid, proc_kgid);
 
 	return 0;
 }
@@ -2539,6 +2568,11 @@ static int __init init(void) {
 	const char *err;
 
 	printk(KERN_NOTICE "Registering xt_RTPENGINE module - version %s\n", RTPENGINE_VERSION);
+	if (set_proc_id) {
+		printk(KERN_NOTICE "using uid %u, gid %d\n", proc_uid, proc_gid);
+		proc_kuid = KUIDT_INIT(proc_uid);
+		proc_kgid = KGIDT_INIT(proc_gid);
+	}
 
 	rwlock_init(&table_lock);
 
@@ -2547,6 +2581,9 @@ static int __init init(void) {
 	my_proc_root = proc_mkdir("rtpengine", NULL);
 	if (!my_proc_root)
 		goto fail;
+
+	if (set_proc_id)
+		proc_set_user(my_proc_root, proc_kuid, proc_kgid);
 	/* my_proc_root->owner = THIS_MODULE; */
 
 	proc_control = proc_create("control", S_IFREG | S_IWUSR | S_IWGRP, my_proc_root,
@@ -2554,9 +2591,15 @@ static int __init init(void) {
 	if (!proc_control)
 		goto fail;
 
+	if (set_proc_id)
+		proc_set_user(proc_control, proc_kuid, proc_kgid);
+
 	proc_list = proc_create("list", S_IFREG | S_IRUGO, my_proc_root, &proc_main_list_ops);
 	if (!proc_list)
 		goto fail;
+
+	if (set_proc_id)
+		proc_set_user(proc_list, proc_kuid, proc_kgid);
 
 	err = "could not register xtables target";
 	ret = xt_register_targets(xt_rtpengine_regs, ARRAY_SIZE(xt_rtpengine_regs));


### PR DESCRIPTION
This patch adds parameters to the kernel module, to choose the userid and groupid of the files in the /proc/rtpengine tree, allowing non-root users to run and control rtpengine.