### PR TITLE
Update ctl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ The options are described in more detail below.
 
 	Add a prefix for every graphite line.
 
+* --max-sessions
+
+	Limit the number of maximum concurrent sessions. Set at startup via MAX_SESSIONS in config file. Set at runtime via rtpengine-ctl util.
+	Setting the 'rtpengine-ctl set maxsessions 0' can be used in draining rtpengine sessions.
+	Enable feature: 'MAX_SESSIONS=1000'
+	Enable feature: 'rtpengine-ctl set maxsessions' >=0
+	Disable feature: 'rtpengine-ctl set maxsessions -1'
+	By default, the feature is disabled (i.e. maxsessions == -1).
+
+
 A typical command line (enabling both UDP and NG protocols) thus may look like:
 
 	/usr/sbin/rtpengine --table=0 --interface=10.64.73.31 --interface=2001:db8::4f3:3d \

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -751,7 +751,7 @@ out:
 const char *call_offer_ng(bencode_item_t *input, struct callmaster *m, bencode_item_t *output, const char* addr,
 		const endpoint_t *sin)
 {
-	if (m->conf.max_sessions>0) {
+	if (m->conf.max_sessions>=0) {
 		rwlock_lock_r(&m->hashlock);
 		if (g_hash_table_size(m->callhash) >= m->conf.max_sessions) {
 			rwlock_unlock_r(&m->hashlock);

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -105,6 +105,14 @@ static void cli_incoming_list_totals(char* buffer, int len, struct callmaster* m
 	g_list_free(list);
 }
 
+static void cli_incoming_list_maxsessions(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
+	int printlen=0;
+
+	/* don't lock while reading the value */
+	printlen = snprintf(replybuffer,(outbufend-replybuffer), "Maximum sessions configured on rtpengine: %d\n", m->conf.max_sessions);
+	ADJUSTLEN(printlen,outbufend,replybuffer);
+}
+
 static void cli_incoming_list_callid(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
    str callid;
    struct call* c=0;
@@ -263,6 +271,7 @@ static void cli_incoming_list(char* buffer, int len, struct callmaster* m, char*
    static const char* LIST_SESSIONS = "sessions";
    static const char* LIST_SESSION = "session";
    static const char* LIST_TOTALS = "totals";
+   static const char* LIST_MAX_SESSIONS = "maxsessions";
 
    if (len<=1) {
        printlen = snprintf(replybuffer, outbufend-replybuffer, "%s\n", "More parameters required.");
@@ -273,7 +282,7 @@ static void cli_incoming_list(char* buffer, int len, struct callmaster* m, char*
 
    if (len>=strlen(LIST_NUMSESSIONS) && strncmp(buffer,LIST_NUMSESSIONS,strlen(LIST_NUMSESSIONS)) == 0) {
        rwlock_lock_r(&m->hashlock);
-       printlen = snprintf(replybuffer, outbufend-replybuffer, "Current Sessions on rtpengine:%i\n", g_hash_table_size(m->callhash));
+       printlen = snprintf(replybuffer, outbufend-replybuffer, "Current sessions running on rtpengine: %i\n", g_hash_table_size(m->callhash));
        ADJUSTLEN(printlen,outbufend,replybuffer);
        rwlock_unlock_r(&m->hashlock);
    } else if (len>=strlen(LIST_SESSIONS) && strncmp(buffer,LIST_SESSIONS,strlen(LIST_SESSIONS)) == 0) {
@@ -296,6 +305,8 @@ static void cli_incoming_list(char* buffer, int len, struct callmaster* m, char*
        cli_incoming_list_callid(buffer+strlen(LIST_SESSION), len-strlen(LIST_SESSION), m, replybuffer, outbufend);
    } else if (len>=strlen(LIST_TOTALS) && strncmp(buffer,LIST_TOTALS,strlen(LIST_TOTALS)) == 0) {
        cli_incoming_list_totals(buffer+strlen(LIST_TOTALS), len-strlen(LIST_TOTALS), m, replybuffer, outbufend);
+   } else if (len>=strlen(LIST_MAX_SESSIONS) && strncmp(buffer,LIST_MAX_SESSIONS,strlen(LIST_MAX_SESSIONS)) == 0) {
+       cli_incoming_list_maxsessions(buffer+strlen(LIST_MAX_SESSIONS), len-strlen(LIST_MAX_SESSIONS), m, replybuffer, outbufend);
    } else {
        printlen = snprintf(replybuffer, outbufend-replybuffer, "%s:%s\n", "Unknown 'list' command", buffer);
        ADJUSTLEN(printlen,outbufend,replybuffer);

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -108,7 +108,7 @@ static void cli_incoming_list_totals(char* buffer, int len, struct callmaster* m
 static void cli_incoming_list_maxsessions(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
 	int printlen=0;
 
-	/* don't lock while reading the value */
+	/* don't lock anything while reading the value */
 	printlen = snprintf(replybuffer,(outbufend-replybuffer), "Maximum sessions configured on rtpengine: %d\n", m->conf.max_sessions);
 	ADJUSTLEN(printlen,outbufend,replybuffer);
 }
@@ -260,6 +260,38 @@ static void cli_incoming_set_max_open_files(char* buffer, int len, struct callma
 	}
 }
 
+static void cli_incoming_set_maxsessions(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
+	int printlen = 0;
+	int maxsessions_num;
+	str maxsessions;
+
+	if (len<=1) {
+		printlen = snprintf(replybuffer,(outbufend-replybuffer), "%s\n", "More parameters required.");
+		ADJUSTLEN(printlen,outbufend,replybuffer);
+		return;
+	}
+
+	++buffer; --len; // one space
+	maxsessions.s = buffer;
+	maxsessions.len = len;
+	maxsessions_num = str_to_i(&maxsessions, -1);
+
+	if (maxsessions_num == -1) {
+		printlen = snprintf (replybuffer,(outbufend-replybuffer), "Fail setting maxsessions to %.*s; not an integer\n", maxsessions.len, maxsessions.s);
+		ADJUSTLEN(printlen,outbufend,replybuffer);
+		return;
+	} else if (maxsessions_num < 0) {
+		printlen = snprintf (replybuffer,(outbufend-replybuffer), "Fail setting maxsessions to %d; negative value\n", maxsessions_num);
+		ADJUSTLEN(printlen,outbufend,replybuffer);
+		return;
+	} else {
+		/* don't lock anything while writing the value - only this command modifies its value */
+		m->conf.max_sessions = maxsessions_num;
+		printlen = snprintf (replybuffer,(outbufend-replybuffer), "Success setting maxsessions to %d\n", maxsessions_num);
+		ADJUSTLEN(printlen,outbufend,replybuffer);
+	}
+}
+
 static void cli_incoming_list(char* buffer, int len, struct callmaster* m, char* replybuffer, const char* outbufend) {
    GHashTableIter iter;
    gpointer key, value;
@@ -317,6 +349,7 @@ static void cli_incoming_set(char* buffer, int len, struct callmaster* m, char* 
 	int printlen=0;
 
 	static const char* SET_OPEN_FILES = "max-open-files";
+	static const char* SET_MAX_SESSIONS = "maxsessions";
 
 	if (len<=1) {
 		printlen = snprintf(replybuffer, outbufend-replybuffer, "%s\n", "More parameters required.");
@@ -327,6 +360,8 @@ static void cli_incoming_set(char* buffer, int len, struct callmaster* m, char* 
 
 	if (len>=strlen(SET_OPEN_FILES) && strncmp(buffer,SET_OPEN_FILES,strlen(SET_OPEN_FILES)) == 0) {
 		cli_incoming_set_max_open_files(buffer+strlen(SET_OPEN_FILES), len-strlen(SET_OPEN_FILES), m, replybuffer, outbufend);
+	} else if (len>=strlen(SET_MAX_SESSIONS) && strncmp(buffer,SET_MAX_SESSIONS,strlen(SET_MAX_SESSIONS)) == 0) {
+		cli_incoming_set_maxsessions(buffer+strlen(SET_MAX_SESSIONS), len-strlen(SET_MAX_SESSIONS), m, replybuffer, outbufend);
 	} else {
 		printlen = snprintf(replybuffer, outbufend-replybuffer, "%s:%s\n", "Unknown 'set' command", buffer);
 		ADJUSTLEN(printlen,outbufend,replybuffer);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -74,7 +74,7 @@ static int timeout;
 static int silent_timeout;
 static int port_min = 30000;
 static int port_max = 40000;
-static int max_sessions = 0;
+static int max_sessions = -1;
 static int redis_db = -1;
 static int redis_read_db = -1;
 static int redis_write_db = -1;
@@ -514,6 +514,9 @@ no_kernel:
 	ZERO(mc);
 	mc.kernelfd = kfd;
 	mc.kernelid = table;
+	if (max_sessions < -1) {
+		max_sessions = -1;
+	}
 	mc.max_sessions = max_sessions;
 	mc.timeout = timeout;
 	mc.silent_timeout = silent_timeout;

--- a/daemon/str.h
+++ b/daemon/str.h
@@ -249,6 +249,7 @@ INLINE void str_swap(str *a, str *b) {
 INLINE int str_to_i(str *s, int def) {
 	char c, *ep;
 	long ret;
+	int maxint = 0x7FFFFFFF;
 	if (s->len <= 0)
 		return def;
 	c = s->s[s->len];
@@ -256,6 +257,8 @@ INLINE int str_to_i(str *s, int def) {
 	ret = strtol(s->s, &ep, 10);
 	s->s[s->len] = c;
 	if (ep == s->s)
+		return def;
+	if (ret > maxint)
 		return def;
 	return ret;
 }

--- a/daemon/str.h
+++ b/daemon/str.h
@@ -250,6 +250,7 @@ INLINE int str_to_i(str *s, int def) {
 	char c, *ep;
 	long ret;
 	int maxint = 0x7FFFFFFF;
+	int minint = 0x80000000;
 	if (s->len <= 0)
 		return def;
 	c = s->s[s->len];
@@ -259,6 +260,8 @@ INLINE int str_to_i(str *s, int def) {
 	if (ep == s->s)
 		return def;
 	if (ret > maxint)
+		return def;
+	if (ret < minint)
 		return def;
 	return ret;
 }

--- a/utils/rtpengine-ctl
+++ b/utils/rtpengine-ctl
@@ -62,8 +62,10 @@ sub showusage {
     print "\n";
     print "    Supported commands are:\n";
     print "\n";
-    print "    list [ numsessions | sessions | session <callid> | totals ]\n";
-    print "         numsessions           : prints the number of sessions\n";
+    print "    list [ numsessions | maxsessions | maxopenfiles | sessions | session <callid> | totals ]\n";
+    print "         numsessions           : print the number of sessions\n";
+    print "         maxsessions           : print the number of allowed sessions\n";
+    print "         maxopenfiles          : print the number of allowed open files\n";
     print "         sessions              : print one-liner session information\n";
     print "         session <callid>      : print detail about one session\n";
     print "         totals                : print total statistics\n";
@@ -72,8 +74,9 @@ sub showusage {
     print "         all                   : terminates all current sessions\n";
     print "         <callid>              : session is immediately terminated\n";
     print "\n";
-    print "    set [ max-open-files <uint> ]\n";
-    print "         max-open-files <uint> : increase the max nr of allowed open files\n";
+    print "    set [ maxopenfiles <uint> | maxsessions <int> ]\n";
+    print "         maxsessions  <int>    : set the max nr of allowed sessions\n";
+    print "         maxopenfiles <uint>   : set the max nr of allowed open files\n";
     print "\n";
     print "\n";
     print "    Return Value:\n";


### PR DESCRIPTION
Focus on set/get maxsessions.
Allow 0 value for maxsessions(useful for draining rtpengine); disable the feature for -1 value; other negative values are ignored.