### PR TITLE
Fix segfault when ps->component=0

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -781,6 +781,7 @@ static void __assign_stream_fds(struct call_media *media, GQueue *intf_sfds) {
 			il = l->data;
 
 			sfd = g_queue_peek_nth(&il->list, ps->component - 1);
+			if (!sfd) return ;
 
 			sfd->stream = ps;
 			g_queue_push_tail(&ps->sfds, sfd);

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -674,6 +674,8 @@ static int redis_streams(struct call *c, struct redis_list *streams) {
 		atomic64_set_na(&ps->last_packet, time(NULL));
 		if (redis_hash_get_unsigned((unsigned int *) &ps->ps_flags, rh, "ps_flags"))
 			return -1;
+		if (redis_hash_get_unsigned((unsigned int *) &ps->component, rh, "component"))
+			return -1;
 		if (redis_hash_get_endpoint(&ps->endpoint, rh, "endpoint"))
 			return -1;
 		if (redis_hash_get_endpoint(&ps->advertised_endpoint, rh, "advertised_endpoint"))
@@ -1318,7 +1320,7 @@ void redis_update(struct call *c, struct redis *r) {
 
 		redis_pipe(r, "HMSET stream-"PB"-%u media %u sfd %u rtp_sink %u "
 			"rtcp_sink %u rtcp_sibling %u last_packet "UINT64F" "
-			"ps_flags %u",
+			"ps_flags %u component %u",
 			STR(&c->callid), ps->unique_id,
 			ps->media->unique_id,
 			ps->selected_sfd ? ps->selected_sfd->unique_id : -1,
@@ -1326,7 +1328,8 @@ void redis_update(struct call *c, struct redis *r) {
 			ps->rtcp_sink ? ps->rtcp_sink->unique_id : -1,
 			ps->rtcp_sibling ? ps->rtcp_sibling->unique_id : -1,
 			atomic64_get(&ps->last_packet),
-			ps->ps_flags);
+			ps->ps_flags,
+			ps->component);
 		redis_update_endpoint(r, "stream", &c->callid, ps->unique_id, "endpoint", &ps->endpoint);
 		redis_update_endpoint(r, "stream", &c->callid, ps->unique_id, "advertised_endpoint",
 				&ps->advertised_endpoint);


### PR DESCRIPTION
@pkuzak discovered a scenario which constantly lead to rtpengine coredump segfault:
1. Make a call with UAS answering with 183 Session Progress (rtpengine will kernelize and store stuff into Redis. Do **not** finally answer the call.
2. Restart rtpengine
3. Finally answer the call ==> Segfault and coredump

Investigating the coredump we saw that ps->component was 0 in this case, leading to a NULL sfd due to "sfd = g_queue_peek_nth(&il->list, ps->component - 1);"

Related commit: b0a38982c2eebfe55ec8b4761505d7af17774718