### PR TITLE
Made interactions with recording metadata threadsafe

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -749,10 +749,13 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	}
 	bencode_dictionary_get_str(input, "metadata", &metadata);
 	if (metadata.len > 0 && call->recording != NULL) {
+		mutex_lock(&call->recording->metadata_lock);
 		if (call->recording->metadata != NULL) {
 			free(call->recording->metadata);
+			call->recording->metadata = NULL;
 		}
 		call->recording->metadata = str_dup(&metadata);
+		mutex_unlock(&call->recording->metadata_lock);
 	}
 	bencode_item_t *recordings = bencode_dictionary_add_list(output, "recordings");
 	if (call->recording != NULL && call->recording->recording_path != NULL) {

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -720,6 +720,27 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	if (!ret)
 		ret = sdp_replace(chopper, &parsed, monologue->active_dialogue, &flags);
 
+	struct recording *recording = call->recording;
+	if (call->record_call && recording != NULL && recording->meta_fp != NULL) {
+		struct iovec *iov = &g_array_index(chopper->iov, struct iovec, 0);
+		int iovcnt = chopper->iov_num;
+		meta_write_sdp(recording->meta_fp, iov, iovcnt,
+			       call->recording->packet_num, opmode);
+	}
+	bencode_dictionary_get_str(input, "metadata", &metadata);
+	if (metadata.len > 0 && call->recording != NULL) {
+		if (call->recording->metadata != NULL) {
+			free(call->recording->metadata);
+			call->recording->metadata = NULL;
+		}
+		call->recording->metadata = str_dup(&metadata);
+	}
+	bencode_item_t *recordings = bencode_dictionary_add_list(output, "recordings");
+	if (call->recording != NULL && call->recording->recording_path != NULL) {
+		char *recording_path = call->recording->recording_path->s;
+		bencode_list_add_string(recordings, recording_path);
+	}
+
 	rwlock_unlock_w(&call->master_lock);
 	redis_update(call, m->conf.redis_write);
 	obj_put(call);
@@ -739,29 +760,6 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	bencode_dictionary_add_iovec(output, "sdp", &g_array_index(chopper->iov, struct iovec, 0),
 		chopper->iov_num, chopper->str_len);
 	bencode_dictionary_add_string(output, "result", "ok");
-
-	struct recording *recording = call->recording;
-	if (call->record_call && recording != NULL && recording->meta_fp != NULL) {
-		struct iovec *iov = &g_array_index(chopper->iov, struct iovec, 0);
-		int iovcnt = chopper->iov_num;
-		meta_write_sdp(recording->meta_fp, iov, iovcnt,
-			       call->recording->packet_num, opmode);
-	}
-	bencode_dictionary_get_str(input, "metadata", &metadata);
-	if (metadata.len > 0 && call->recording != NULL) {
-		mutex_lock(&call->recording->metadata_lock);
-		if (call->recording->metadata != NULL) {
-			free(call->recording->metadata);
-			call->recording->metadata = NULL;
-		}
-		call->recording->metadata = str_dup(&metadata);
-		mutex_unlock(&call->recording->metadata_lock);
-	}
-	bencode_item_t *recordings = bencode_dictionary_add_list(output, "recordings");
-	if (call->recording != NULL && call->recording->recording_path != NULL) {
-		char *recording_path = call->recording->recording_path->s;
-		bencode_list_add_string(recordings, recording_path);
-	}
 
 	errstr = NULL;
 out:

--- a/daemon/recording.h
+++ b/daemon/recording.h
@@ -24,7 +24,6 @@ struct recording {
 	str           *recording_path;
 
 	mutex_t       recording_lock;
-	mutex_t       metadata_lock;
 };
 
 

--- a/daemon/recording.h
+++ b/daemon/recording.h
@@ -24,6 +24,7 @@ struct recording {
 	str           *recording_path;
 
 	mutex_t       recording_lock;
+	mutex_t       metadata_lock;
 };
 
 


### PR DESCRIPTION
Updating, freeing, and writing the recording metadata is now threadsafe. This is in regards to the metadata that we receive from the `rtpengine_offer` or `rtpengine_answer` commands, not the `meta_fp` file.

We got an rtpengine crash that happened when calling `free(call->recording->metadata);` at https://github.com/sipwise/rtpengine/blob/master/daemon/call_interfaces.c#L753.

We are pretty sure this happened due to a double-free, but weren't able to exactly reproduce this in the code. Either way, if `call_offer_answer_ng` can be called simultaneously in multiple threads, it was technically possible to attempt to double-free the `recording->metadata` string. A mutex lock prevents that.