### PR TITLE
Made interactions to recording metadata threadsafe

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -720,6 +720,27 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	if (!ret)
 		ret = sdp_replace(chopper, &parsed, monologue->active_dialogue, &flags);
 
+	struct recording *recording = call->recording;
+	if (call->record_call && recording != NULL && recording->meta_fp != NULL) {
+		struct iovec *iov = &g_array_index(chopper->iov, struct iovec, 0);
+		int iovcnt = chopper->iov_num;
+		meta_write_sdp(recording->meta_fp, iov, iovcnt,
+			       call->recording->packet_num, opmode);
+	}
+	bencode_dictionary_get_str(input, "metadata", &metadata);
+	if (metadata.len > 0 && call->recording != NULL) {
+		if (call->recording->metadata != NULL) {
+			free(call->recording->metadata);
+			call->recording->metadata = NULL;
+		}
+		call->recording->metadata = str_dup(&metadata);
+	}
+	bencode_item_t *recordings = bencode_dictionary_add_list(output, "recordings");
+	if (call->recording != NULL && call->recording->recording_path != NULL) {
+		char *recording_path = call->recording->recording_path->s;
+		bencode_list_add_string(recordings, recording_path);
+	}
+
 	rwlock_unlock_w(&call->master_lock);
 	redis_update(call, m->conf.redis_write);
 	obj_put(call);
@@ -739,26 +760,6 @@ static const char *call_offer_answer_ng(bencode_item_t *input, struct callmaster
 	bencode_dictionary_add_iovec(output, "sdp", &g_array_index(chopper->iov, struct iovec, 0),
 		chopper->iov_num, chopper->str_len);
 	bencode_dictionary_add_string(output, "result", "ok");
-
-	struct recording *recording = call->recording;
-	if (call->record_call && recording != NULL && recording->meta_fp != NULL) {
-		struct iovec *iov = &g_array_index(chopper->iov, struct iovec, 0);
-		int iovcnt = chopper->iov_num;
-		meta_write_sdp(recording->meta_fp, iov, iovcnt,
-			       call->recording->packet_num, opmode);
-	}
-	bencode_dictionary_get_str(input, "metadata", &metadata);
-	if (metadata.len > 0 && call->recording != NULL) {
-		if (call->recording->metadata != NULL) {
-			free(call->recording->metadata);
-		}
-		call->recording->metadata = str_dup(&metadata);
-	}
-	bencode_item_t *recordings = bencode_dictionary_add_list(output, "recordings");
-	if (call->recording != NULL && call->recording->recording_path != NULL) {
-		char *recording_path = call->recording->recording_path->s;
-		bencode_list_add_string(recordings, recording_path);
-	}
 
 	errstr = NULL;
 out:

--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -231,6 +231,7 @@ ssize_t meta_write_sdp(FILE *meta_fp, struct iovec *sdp_iov, int iovcnt,
  * Returns non-zero for failure.
  */
 int meta_finish_file(struct call *call) {
+	// This should usually be called from a place that has the call->master_lock
 	struct recording *recording = call->recording;
 	int return_code = 0;
 
@@ -251,6 +252,7 @@ int meta_finish_file(struct call *call) {
 		// Print metadata
 		fprintf(recording->meta_fp, "\n\n%s\n", recording->metadata->s);
 		free(recording->metadata);
+		recording->metadata = NULL;
 		fclose(recording->meta_fp);
 
 		// Get the filename (in between its directory and the file extension)


### PR DESCRIPTION
Updating, freeing, and writing the recording metadata is now
threadsafe. This is in regards to the metadata that we receive from
the `rtpengine_offer` or `rtpengine_answer` commands, not the
`meta_fp` file.

We can simply use the `call->master_lock` variable for protecting
updates to the recording metadata. We had to move the metadata
handling code in call_interfaces.c up into the master_lock guarded
section. The code in "recording.c:meta_finish_file" is called with
master_lock protection already.