### PR TITLE
Various minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ option and which are reproduced below:
 	  -w, --redis-write=[PW@]IP:PORT/INT Connect to Redis write database
 	  -k, --subscribe-keyspace         Subscription keyspace list
 	  --redis-num-threads=INT          Number of Redis restore threads
+	  --redis-expires=INT              Expire time in seconds for redis keys	 
 	  -q, --no-redis-required          Start even if can't connect to redis databases
 	  -b, --b2b-url=STRING             XMLRPC URL of B2B UA
 	  -L, --log-level=INT              Mask log priorities above this level
@@ -419,6 +420,10 @@ The options are described in more detail below.
 *  --redis-num-threads
 
 	How many redis restore threads to create. The default is four.
+
+*  --redis-expires
+
+        Expire time in seconds for redis keys. Default is 86400.
 
 *  -q, --no-redis-required
 	When this paramter is present or NO_REDIS_REQUIRED='yes' or '1' in config file, rtpengine starts even

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1980,7 +1980,7 @@ void call_destroy(struct call *c) {
 						continue;
 	
 					char *addr = sockaddr_print_buf(&ps->endpoint.address);
-                    char *local_addr = ps->selected_sfd ? sockaddr_print_buf(&ps->selected_sfd->socket.local.address) : "0.0.0.0";
+                                        char *local_addr = ps->selected_sfd ? sockaddr_print_buf(&ps->selected_sfd->socket.local.address) : "0.0.0.0";
 	
 					if (_log_facility_cdr) {
 					    const char* protocol = (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? "rtcp" : "rtp";
@@ -1989,7 +1989,7 @@ void call_destroy(struct call *c) {
 						printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
-						    "ml%i_midx%u_%s_local_relay_ip=%s, "
+  						        "ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
@@ -2017,7 +2017,7 @@ void call_destroy(struct call *c) {
 					    	printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
-					    	"ml%i_midx%u_%s_local_relay_ip=%s, "
+					    	        "ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
@@ -2049,7 +2049,7 @@ void call_destroy(struct call *c) {
 						printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
-						    "ml%i_midx%u_%s_local_relay_ip=%s, "
+  						        "ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1980,6 +1980,7 @@ void call_destroy(struct call *c) {
 						continue;
 	
 					char *addr = sockaddr_print_buf(&ps->endpoint.address);
+                    char *local_addr = ps->selected_sfd ? sockaddr_print_buf(&ps->selected_sfd->socket.local.address) : "0.0.0.0";
 	
 					if (_log_facility_cdr) {
 					    const char* protocol = (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? "rtcp" : "rtp";
@@ -1988,6 +1989,7 @@ void call_destroy(struct call *c) {
 						printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
+						    "ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
@@ -1996,6 +1998,7 @@ void call_destroy(struct call *c) {
 							"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
 							cdrlinecnt, md->index, protocol, addr,
 							cdrlinecnt, md->index, protocol, ps->endpoint.port,
+							cdrlinecnt, md->index, protocol, local_addr,
 							cdrlinecnt, md->index, protocol,
 							(ps->selected_sfd ? ps->selected_sfd->socket.local.port : 0),
 							cdrlinecnt, md->index, protocol,
@@ -2014,6 +2017,7 @@ void call_destroy(struct call *c) {
 					    	printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
+					    	"ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
@@ -2025,6 +2029,7 @@ void call_destroy(struct call *c) {
 							"ml%i_midx%u_%s_delay_max=%.9f, ",
 							cdrlinecnt, md->index, protocol, addr,
 							cdrlinecnt, md->index, protocol, ps->endpoint.port,
+							cdrlinecnt, md->index, protocol, local_addr,
 							cdrlinecnt, md->index, protocol, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
 							cdrlinecnt, md->index, protocol,
 							atomic64_get(&ps->stats.packets),
@@ -2044,6 +2049,7 @@ void call_destroy(struct call *c) {
 						printlen = snprintf(cdrbufcur, CDRBUFREMAINDER,
 							"ml%i_midx%u_%s_endpoint_ip=%s, "
 							"ml%i_midx%u_%s_endpoint_port=%u, "
+						    "ml%i_midx%u_%s_local_relay_ip=%s, "
 							"ml%i_midx%u_%s_local_relay_port=%u, "
 							"ml%i_midx%u_%s_relayed_packets="UINT64F", "
 							"ml%i_midx%u_%s_relayed_bytes="UINT64F", "
@@ -2052,6 +2058,7 @@ void call_destroy(struct call *c) {
 							"ml%i_midx%u_%s_in_tos_tclass=%" PRIu8 ", ",
 							cdrlinecnt, md->index, protocol, addr,
 							cdrlinecnt, md->index, protocol, ps->endpoint.port,
+							cdrlinecnt, md->index, protocol, local_addr,
 							cdrlinecnt, md->index, protocol,
 							(ps->selected_sfd ? ps->selected_sfd->socket.local.port : 0),
 							cdrlinecnt, md->index, protocol,
@@ -2069,8 +2076,8 @@ void call_destroy(struct call *c) {
 					    }
 					}
 	
-					ilog(LOG_INFO, "--------- Port %5u <> %15s:%-5u%s, "
-							""UINT64F" p, "UINT64F" b, "UINT64F" e, "UINT64F" last_packet",
+					ilog(LOG_INFO, "--------- Port %15s:%-5u <> %15s:%-5u%s, "
+							""UINT64F" p, "UINT64F" b, "UINT64F" e, "UINT64F" last_packet", local_addr,
 							(unsigned int) (ps->selected_sfd ? ps->selected_sfd->socket.local.port : 0),
 							addr, ps->endpoint.port,
 							(!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? " (RTCP)" : "",

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -245,37 +245,35 @@ struct request_time {
 };
 
 struct totalstats {
-	time_t 				started;
-	atomic64			total_timeout_sess;
-	atomic64			total_foreign_sessions;
-	atomic64			total_rejected_sess;
-	atomic64			total_silent_timeout_sess;
-	atomic64			total_final_timeout_sess;
-	atomic64			total_regular_term_sess;
-	atomic64			total_forced_term_sess;
-	atomic64			total_relayed_packets;
-	atomic64			total_relayed_errors;
-	atomic64			total_nopacket_relayed_sess;
-	atomic64			total_oneway_stream_sess;
+	time_t 			started;
+	atomic64		total_timeout_sess;
+	atomic64		total_foreign_sessions;
+	atomic64		total_rejected_sess;
+	atomic64		total_silent_timeout_sess;
+	atomic64		total_final_timeout_sess;
+	atomic64		total_regular_term_sess;
+	atomic64		total_forced_term_sess;
+	atomic64		total_relayed_packets;
+	atomic64		total_relayed_errors;
+	atomic64		total_nopacket_relayed_sess;
+	atomic64		total_oneway_stream_sess;
 
-	u_int64_t           foreign_sessions;
-	u_int64_t           own_sessions;
-	u_int64_t           total_sessions;
+	u_int64_t               foreign_sessions;
+	u_int64_t               own_sessions;
+	u_int64_t               total_sessions;
 
-	mutex_t				total_average_lock; /* for these two below */
-	u_int64_t			total_managed_sess;
+	mutex_t			total_average_lock; /* for these two below */
+	u_int64_t		total_managed_sess;
 	struct timeval		total_average_call_dur;
 
-	mutex_t				managed_sess_lock; /* for these below */
-	u_int64_t			managed_sess_max; /* per graphite interval statistic */
-	u_int64_t			managed_sess_min; /* per graphite interval statistic */
+	mutex_t			managed_sess_lock; /* for these below */
+	u_int64_t		managed_sess_max; /* per graphite interval statistic */
+	u_int64_t		managed_sess_min; /* per graphite interval statistic */
 
-	mutex_t				total_calls_duration_lock; /* for these two below */
+	mutex_t			total_calls_duration_lock; /* for these two below */
 	struct timeval		total_calls_duration_interval;
 
-
-
-	struct request_time		offer, answer, delete;
+	struct request_time	offer, answer, delete;
 };
 
 struct stream_params {
@@ -461,7 +459,7 @@ struct callmaster_config {
 	struct event_base   *redis_notify_event_base;
 	GQueue		        *redis_subscribed_keyspaces;
 	struct redisAsyncContext *redis_notify_async_context;
-	unsigned int        redis_expires_secs;
+	unsigned int            redis_expires_secs;
 	char			*b2b_url;
 	unsigned char		default_tos;
 	enum xmlrpc_format	fmt;

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -258,6 +258,10 @@ struct totalstats {
 	atomic64			total_nopacket_relayed_sess;
 	atomic64			total_oneway_stream_sess;
 
+	u_int64_t           foreign_sessions;
+	u_int64_t           own_sessions;
+	u_int64_t           total_sessions;
+
 	mutex_t				total_average_lock; /* for these two below */
 	u_int64_t			total_managed_sess;
 	struct timeval		total_average_call_dur;
@@ -268,6 +272,8 @@ struct totalstats {
 
 	mutex_t				total_calls_duration_lock; /* for these two below */
 	struct timeval		total_calls_duration_interval;
+
+
 
 	struct request_time		offer, answer, delete;
 };

--- a/daemon/call.h
+++ b/daemon/call.h
@@ -455,6 +455,7 @@ struct callmaster_config {
 	struct event_base   *redis_notify_event_base;
 	GQueue		        *redis_subscribed_keyspaces;
 	struct redisAsyncContext *redis_notify_async_context;
+	unsigned int        redis_expires_secs;
 	char			*b2b_url;
 	unsigned char		default_tos;
 	enum xmlrpc_format	fmt;

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -262,6 +262,7 @@ static void cli_incoming_list_callid(char* buffer, int len, struct callmaster* m
    int printlen=0;
    struct timeval tim_result_duration;
    struct timeval now;
+   char * local_addr;
 
    if (len<=1) {
        printlen = snprintf(replybuffer,(outbufend-replybuffer), "%s\n", "More parameters required.");
@@ -309,12 +310,13 @@ static void cli_incoming_list_callid(char* buffer, int len, struct callmaster* m
                if (PS_ISSET(ps, FALLBACK_RTCP))
                    continue;
 
+               local_addr = ps->selected_sfd ? sockaddr_print_buf(&ps->selected_sfd->socket.local.address) : "0.0.0.0";
 #if (RE_HAS_MEASUREDELAY)
                if (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) {
-            	   printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, port %5u <> %15s:%-5hu%s, "
+		   printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, %15s:%-5hu <> %15s:%-5hu%s, "
             			   ""UINT64F" p, "UINT64F" b, "UINT64F" e, "UINT64F" last_packet\n",
 						   md->index,
-						   (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
+						   local_addr, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
 						   sockaddr_print_buf(&ps->endpoint.ip46), ps->endpoint.port,
 						   (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? " (RTCP)" : "",
 								   atomic64_get(&ps->stats.packets),
@@ -322,10 +324,10 @@ static void cli_incoming_list_callid(char* buffer, int len, struct callmaster* m
 								   atomic64_get(&ps->stats.errors),
 								   atomic64_get(&ps->last_packet));
                } else {
-            	   printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, port %5u <> %15s:%-5hu%s, "
+		   printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, %15s:%-5hu <> %15s:%-5hu%s, "
 			   ""UINT64F" p, "UINT64F" b, "UINT64F" e, "UINT64F" last_packet, %.9f delay_min, %.9f delay_avg, %.9f delay_max\n",
 						   md->index,
-						   (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
+						   local_addr, (unsigned int) (ps->sfd ? ps->sfd->fd.localport : 0),
 						   sockaddr_print_buf(&ps->endpoint.ip46), ps->endpoint.port,
 						   (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? " (RTCP)" : "",
 								   atomic64_get(&ps->stats.packets),
@@ -337,10 +339,10 @@ static void cli_incoming_list_callid(char* buffer, int len, struct callmaster* m
 								   (double) ps->stats.delay_max / 1000000);
                }
 #else
-               printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, port %5u <> %15s:%-5u%s, "
+               printlen = snprintf(replybuffer,(outbufend-replybuffer), "------ Media #%u, %15s:%-5u <> %15s:%-5u%s, "
                     ""UINT64F" p, "UINT64F" b, "UINT64F" e, "UINT64F" last_packet\n",
                     md->index,
-                    (unsigned int) (ps->selected_sfd ? ps->selected_sfd->socket.local.port : 0),
+                    local_addr, (unsigned int) (ps->selected_sfd ? ps->selected_sfd->socket.local.port : 0),
                     sockaddr_print_buf(&ps->endpoint.address), ps->endpoint.port,
                     (!PS_ISSET(ps, RTP) && PS_ISSET(ps, RTCP)) ? " (RTCP)" : "",
                          atomic64_get(&ps->stats.packets),

--- a/daemon/graphite.c
+++ b/daemon/graphite.c
@@ -134,11 +134,11 @@ int send_graphite_data(struct callmaster *cm, struct totalstats *sent_data) {
 	mutex_lock(&cm->totalstats_interval.managed_sess_lock);
 	ts->managed_sess_max = cm->totalstats_interval.managed_sess_max;
 	ts->managed_sess_min = cm->totalstats_interval.managed_sess_min;
-    ts->total_sessions = g_hash_table_size(cm->callhash);
-    ts->foreign_sessions = atomic64_get(&cm->stats.foreign_sessions);
-    ts->own_sessions = ts->total_sessions - ts->foreign_sessions;
-    cm->totalstats_interval.managed_sess_max = ts->own_sessions;;
-    cm->totalstats_interval.managed_sess_min = ts->own_sessions;
+        ts->total_sessions = g_hash_table_size(cm->callhash);
+        ts->foreign_sessions = atomic64_get(&cm->stats.foreign_sessions);
+	ts->own_sessions = ts->total_sessions - ts->foreign_sessions;
+	cm->totalstats_interval.managed_sess_max = ts->own_sessions;;
+	cm->totalstats_interval.managed_sess_min = ts->own_sessions;
 	mutex_unlock(&cm->totalstats_interval.managed_sess_lock);
 	rwlock_unlock_r(&cm->hashlock);
 
@@ -181,12 +181,12 @@ int send_graphite_data(struct callmaster *cm, struct totalstats *sent_data) {
 	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
 	rc = sprintf(ptr,"managed_sess_max "UINT64F" %llu\n", ts->managed_sess_max,(unsigned long long)g_now.tv_sec); ptr += rc;
 	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
-    rc = sprintf(ptr,"current_sessions_total "UINT64F" %llu\n", ts->total_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
-    if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
-    rc = sprintf(ptr,"current_sessions_own "UINT64F" %llu\n", ts->own_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
-    if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
-    rc = sprintf(ptr,"current_sessions_foreign "UINT64F" %llu\n", ts->foreign_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
-    if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
+	rc = sprintf(ptr,"current_sessions_total "UINT64F" %llu\n", ts->total_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
+	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
+	rc = sprintf(ptr,"current_sessions_own "UINT64F" %llu\n", ts->own_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
+	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
+	rc = sprintf(ptr,"current_sessions_foreign "UINT64F" %llu\n", ts->foreign_sessions,(unsigned long long)g_now.tv_sec); ptr += rc;
+	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
 	rc = sprintf(ptr,"nopacket_relayed_sess "UINT64F" %llu\n", atomic64_get_na(&ts->total_nopacket_relayed_sess),(unsigned long long)g_now.tv_sec); ptr += rc;
 	if (graphite_prefix!=NULL) { rc = sprintf(ptr,"%s",graphite_prefix); ptr += rc; }
 	rc = sprintf(ptr,"oneway_stream_sess "UINT64F" %llu\n", atomic64_get_na(&ts->total_oneway_stream_sess),(unsigned long long)g_now.tv_sec); ptr += rc;

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -90,8 +90,7 @@ void log_to_stderr(int facility_priority, char *format, ...) {
 		return;
 	}
 
-	fprintf(stderr, "[%lu.%06lu] %s: %s\n", (unsigned long) g_now.tv_sec, (unsigned long) g_now.tv_usec,
-			prio_str[facility_priority & LOG_PRIMASK], msg);
+	fprintf(stderr, "[%lu.%06lu] %s\n", (unsigned long) g_now.tv_sec, (unsigned long) g_now.tv_usec, msg);
 
 	free(msg);
 }

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -97,7 +97,7 @@ void log_to_stderr(int facility_priority, char *format, ...) {
 }
 
 void __ilog(int prio, const char *fmt, ...) {
-	char prefix[256];
+	char prefix[300];
 	char *msg, *piece;
 	const char *infix = "";
 	va_list ap;
@@ -107,27 +107,31 @@ void __ilog(int prio, const char *fmt, ...) {
 
 	switch (log_info.e) {
 		case LOG_INFO_NONE:
-			prefix[0] = 0;
+			snprintf(prefix, sizeof(prefix),"%s: ", prio_str[prio & LOG_PRIMASK]);
 			break;
 		case LOG_INFO_CALL:
-			snprintf(prefix, sizeof(prefix), "["STR_FORMAT"] ",
+			snprintf(prefix, sizeof(prefix), "%s: ["STR_FORMAT"]: ",
+					prio_str[prio & LOG_PRIMASK],
 					STR_FMT(&log_info.u.call->callid));
 			break;
 		case LOG_INFO_STREAM_FD:
 			if (log_info.u.stream_fd->call)
-				snprintf(prefix, sizeof(prefix), "["STR_FORMAT" port %5u] ",
+				snprintf(prefix, sizeof(prefix), "%s: ["STR_FORMAT" port %5u]: ",
+						prio_str[prio & LOG_PRIMASK],
 						STR_FMT(&log_info.u.stream_fd->call->callid),
 						log_info.u.stream_fd->socket.local.port);
 			break;
 		case LOG_INFO_STR:
-			snprintf(prefix, sizeof(prefix), "["STR_FORMAT"] ",
+			snprintf(prefix, sizeof(prefix), "%s: ["STR_FORMAT"]: ",
+					prio_str[prio & LOG_PRIMASK],
 					STR_FMT(log_info.u.str));
 			break;
 		case LOG_INFO_C_STRING:
-			snprintf(prefix, sizeof(prefix), "[%s] ", log_info.u.cstr);
+			snprintf(prefix, sizeof(prefix), "%s: [%s]: ", prio_str[prio & LOG_PRIMASK],log_info.u.cstr);
 			break;
 		case LOG_INFO_ICE_AGENT:
-			snprintf(prefix, sizeof(prefix), "["STR_FORMAT"/"STR_FORMAT"/%u] ",
+			snprintf(prefix, sizeof(prefix), "%s: ["STR_FORMAT"/"STR_FORMAT"/%u]: ",
+					prio_str[prio & LOG_PRIMASK],
 					STR_FMT(&log_info.u.ice_agent->call->callid),
 					STR_FMT(&log_info.u.ice_agent->media->monologue->tag),
 					log_info.u.ice_agent->media->index);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -80,7 +80,6 @@ static int max_sessions = -1;
 static int redis_db = -1;
 static int redis_write_db = -1;
 static int redis_num_threads;
-
 static int no_redis_required;
 static char *redis_auth;
 static char *redis_write_auth;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -73,12 +73,14 @@ static int no_fallback;
 static unsigned int timeout;
 static unsigned int silent_timeout;
 static unsigned int final_timeout;
+static unsigned int redis_expires = 86400;
 static int port_min = 30000;
 static int port_max = 40000;
 static int max_sessions = -1;
 static int redis_db = -1;
 static int redis_write_db = -1;
 static int redis_num_threads;
+
 static int no_redis_required;
 static char *redis_auth;
 static char *redis_write_auth;
@@ -308,6 +310,7 @@ static void options(int *argc, char ***argv) {
 		{ "redis",	'r', 0, G_OPTION_ARG_STRING,	&redisps,	"Connect to Redis database",	"[PW@]IP:PORT/INT"	},
 		{ "redis-write",'w', 0, G_OPTION_ARG_STRING,    &redisps_write, "Connect to Redis write database",      "[PW@]IP:PORT/INT"       },
 		{ "redis-num-threads", 0, 0, G_OPTION_ARG_INT, &redis_num_threads, "Number of Redis restore threads",      "INT"       },
+		{ "redis-expires", 0, 0, G_OPTION_ARG_INT, &redis_expires, "Expire time in seconds for redis keys",      "INT"       },
 		{ "no-redis-required", 'q', 0, G_OPTION_ARG_NONE, &no_redis_required, "Start no matter of redis connection state", NULL },
 		{ "b2b-url",	'b', 0, G_OPTION_ARG_STRING,	&b2b_url,	"XMLRPC URL of B2B UA"	,	"STRING"	},
 		{ "log-level",	'L', 0, G_OPTION_ARG_INT,	(void *)&log_level,"Mask log priorities above this level","INT"	},
@@ -659,6 +662,8 @@ no_kernel:
 		if (!mc.redis_write)
 			mc.redis_write = mc.redis;
 	}
+
+	mc.redis_expires_secs = redis_expires;
 
 	ctx->m->conf = mc;
 

--- a/debian/ngcp-rtpengine-daemon.default
+++ b/debian/ngcp-rtpengine-daemon.default
@@ -40,3 +40,4 @@ TABLE=0
 # HOMER_PROTOCOL=udp
 # HOMER_ID=2001
 # RECORDING_DIR=/var/spool/rtpengine/
+# LOG_STDERR="no"

--- a/debian/ngcp-rtpengine-daemon.init
+++ b/debian/ngcp-rtpengine-daemon.init
@@ -55,6 +55,7 @@ if [ ! -z "$SUBSCRIBE_KEYSPACES" ]; then
 		OPTIONS="$OPTIONS --subscribe-keyspace=$ks"
 	done
 fi
+
 [ -z "$ADDRESS" ] || OPTIONS="$OPTIONS --interface=$ADDRESS"
 [ -z "$ADV_ADDRESS" ] || OPTIONS="$OPTIONS!$ADV_ADDRESS"
 [ -z "$ADDRESS_IPV6" ] || OPTIONS="$OPTIONS --interface=$ADDRESS_IPV6"
@@ -97,6 +98,10 @@ OPTIONS="$OPTIONS --table=$TABLE"
 
 if test "$FORK" = "no" ; then
 	OPTIONS="$OPTIONS --foreground"
+fi
+
+if test "$LOG_STDERR" = "yes" ; then
+	OPTIONS="$OPTIONS --log-stderr"
 fi
 
 if [ -x /usr/sbin/ngcp-virt-identify ]; then

--- a/debian/ngcp-rtpengine-daemon.init
+++ b/debian/ngcp-rtpengine-daemon.init
@@ -75,6 +75,7 @@ fi
 [ -z "$REDIS_WRITE" -o -z "$REDIS_WRITE_DB" ] || OPTIONS="$OPTIONS --redis-write=$REDIS_WRITE/$REDIS_WRITE_DB"
 [ -z "$REDIS_WRITE_AUTH_PW" ] || export RTPENGINE_REDIS_WRITE_AUTH_PW="$REDIS_WRITE_AUTH_PW"
 [ -z "$REDIS_NUM_THREADS" ] || OPTIONS="$OPTIONS --redis-num-threads=$REDIS_NUM_THREADS"
+[ -z "$REDIS_EXPIRES" ] || OPTIONS="$OPTIONS --redis-expires=$REDIS_EXPIRES"
 [ -z "$NO_REDIS_REQUIRED" -o \( "$NO_REDIS_REQUIRED" != "1" -a "$NO_REDIS_REQUIRED" != "yes" \) ] || OPTIONS="$OPTIONS --no-redis-required"
 [ -z "$B2B_URL" ] || OPTIONS="$OPTIONS --b2b-url=$B2B_URL"
 [ -z "$NO_FALLBACK" -o \( "$NO_FALLBACK" != "1" -a "$NO_FALLBACK" != "yes" \) ] || OPTIONS="$OPTIONS --no-fallback"


### PR DESCRIPTION
* Report own/foreign/total sessions to Graphite

* Printing severity level within every log message

>     rtpengine[4613]: ERR: Socket connect failed. fd: 25, Reason: Connection refused
                                                             vs
    rtpengine[4613]: Socket connect failed. fd: 25, Reason: Connection refused

* Print relay IP information: add relay IP info in MDR, `rtpengine-ctl list sessions <Call-ID>`, call_destroy()

* Adding redis_expires parameter: default is 86400, but this can be configured