### PR TITLE
Make rtpengine packaging more compatible with el7

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -54,6 +54,7 @@ LDFLAGS+=	-lpcap
 LDFLAGS+=	`pcre-config --libs`
 LDFLAGS+=	`xmlrpc-c-config client --libs`
 LDFLAGS+=	-lhiredis
+LDFLAGS+=       `pkg-config --libs libcurl`
 
 ifneq ($(DBG),yes)
   DPKG_BLDFLGS=	$(shell which dpkg-buildflags 2>/dev/null)

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -1,5 +1,5 @@
 Name:		rtpengine
-Version:	2.3.6
+Version:	4.5.0
 Release:	0%{?dist}
 Summary:	The Sipwise NGCP rtpengine
 
@@ -84,9 +84,17 @@ install -D -p -m644 kernel-module/xt_RTPENGINE.c \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/xt_RTPENGINE.c
 install -D -p -m644 kernel-module/xt_RTPENGINE.h \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/xt_RTPENGINE.h
+mkdir -p %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}
+install -D -p -m644 kernel-module/rtpengine_config.h \
+	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/rtpengine_config.h
 sed -i -e "s/__VERSION__/%{version}-%{release}/g;s/ngcp-rtpengine/rtpengine/g" debian/dkms.conf.in
 install -D -p -m644 debian/dkms.conf.in %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
 
+# For RHEL 7, load the compiled kernel module on boot.
+%if 0%{?rhel} == 7
+  install -D -p -m644 kernel-module/xt_RTPENGINE.modules.load.d \
+           %{buildroot}%{_sysconfdir}/modules-load.d/xt_RTPENGINE.conf
+%endif
 
 %pre
 getent group %{name} >/dev/null || /usr/sbin/groupadd -r %{name}
@@ -142,6 +150,9 @@ true
 
 %files dkms
 %{_usrsrc}/%{name}-%{version}-%{release}/
+%if 0%{?rhel} == 7
+  %{_sysconfdir}/modules-load.d/xt_RTPENGINE.conf
+%endif
 
 
 %changelog

--- a/kernel-module/xt_RTPENGINE.modules.load.d
+++ b/kernel-module/xt_RTPENGINE.modules.load.d
@@ -1,0 +1,2 @@
+# Load xt_RTPENGINE kernel module at boot.
+xt_RTPENGINE


### PR DESCRIPTION
This pull request makes the rtpengine default spec file more compatible with el7. It also allows the installation of the kernel module on el7 using DKMS.