### PR TITLE
avoid coredump for strange cases when redis_update finds structures in ep->intf_sfds to be null

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1285,6 +1285,8 @@ static int redis_link_tags(struct redis *r, struct call *c, struct redis_list *t
 			return -1;
 		for (l = q.head; l; l = l->next) {
 			other_ml = l->data;
+			if (!other_ml)
+			    return -1;
 			g_hash_table_insert(ml->other_tags, &other_ml->tag, other_ml);
 		}
 		g_queue_clear(&q);

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1345,6 +1345,7 @@ static int rbl_cb_intf_sfds(str *s, GQueue *q, struct redis_list *list, void *pt
 	int i;
 	struct intf_list *il;
 	struct endpoint_map *em;
+	void *sfd;
 
 	if (!strncmp(s->s, "loc-", 4)) {
 		il = g_slice_alloc0(sizeof(*il));
@@ -1360,9 +1361,16 @@ static int rbl_cb_intf_sfds(str *s, GQueue *q, struct redis_list *list, void *pt
 	il = g_queue_peek_tail(q);
 	if (!il)
 		return -1;
-	g_queue_push_tail(&il->list, redis_list_get_idx_ptr(list, atoi(s->s)));
+
+	sfd = redis_list_get_idx_ptr(list, atoi(s->s));
+	if (G_UNLIKELY(!sfd))
+	    return -1;
+
+	g_queue_push_tail(&il->list, sfd);
 	return 0;
 }
+
+
 static int redis_link_maps(struct redis *r, struct call *c, struct redis_list *maps,
 		struct redis_list *sfds)
 {


### PR DESCRIPTION
There seems to be a strange race condition in the rtpengine so that we get the following coredump and see that in fact SFDs inside ep->intf_sfds seem to be null.
```
#0  0x000000000041a4a2 in redis_update (c=0x7f24b05c85a0, r=0x143b030) at redis.c:1921
#1  0x00000000004284d6 in call_offer_answer_ng (input=input@entry=0x7f24a17a5da8, m=0x1437d80, output=output@entry=0x7f24a17a5d48, opmode=opmode@entry=OP_ANSWER, addr=addr@entry=0x0, sin=sin@entry=0x0) at call_interfaces.c:766
#2  0x000000000042a890 in call_answer_ng (input=input@entry=0x7f24a17a5da8, m=<optimized out>, output=output@entry=0x7f24a17a5d48) at call_interfaces.c:819
#3  0x000000000041cf89 in control_ng_incoming (obj=0x1439000, buf=<optimized out>, sin=0x7f24c45f0580, addr=0x7f24c45f05a0 "xxx.xxx.xxx.xxx:42770", ul=0x14390a0) at control_ng.c:193
#4  0x000000000041bfc3 in udp_listener_incoming (fd=<optimized out>, p=0x14296a0, x=<optimized out>) at udp_listener.c:56
#5  0x000000000040b9b6 in poller_poll (p=p@entry=0x1426a90, timeout=timeout@entry=100) at poller.c:348
#6  0x000000000040c25d in poller_loop (d=0x1426a90) at poller.c:502
#7  0x000000000040c2df in thread_detach_func (d=0x1427720) at aux.c:143
#8  0x00007f24cbd88b50 in start_thread () from /lib/x86_64-linux-gnu/libpthread.so.0
#9  0x00007f24cbad2fbd in clone () from /lib/x86_64-linux-gnu/libc.so.6
```
The scenario is a little more complex: rtp1 receives an OFFER and until it answers Kamailio timeouts and sends OFFER to rtp2. At ANSWER, rtp2 tries to write information in redis and there it crashes producing the coredump.

rtp2 gets restarted and some time later both it and rtp1 expire the call producing some statistics, which suggest that both rtps think they are responsible for the call (IS_FOREIGN(call) == 0). 

We are not sure how the sfds can get null since we would expect the call setup to end when no more ports are available. Are we wrong here? 

