### PR TITLE
Stricter build dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,11 +4,11 @@ Priority: extra
 Maintainer: Sipwise Development Team <support@sipwise.com>
 Build-Depends: debhelper (>= 5),
                iptables-dev (>= 1.4),
-               libavcodec-dev,
-               libavfilter-dev,
-               libavformat-dev,
-               libavresample-dev,
-               libavutil-dev,
+               libavcodec-dev (>= 6:10),
+               libavfilter-dev (>= 6:10),
+               libavformat-dev (>= 6:10),
+               libavresample-dev (>= 6:10),
+               libavutil-dev (>= 6:10),
                libcurl4-openssl-dev | libcurl4-gnutls-dev | libcurl3-openssl-dev | libcurl3-gnutls-dev,
                libevent-dev (>= 2.0),
                libglib2.0-dev (>= 2.30),
@@ -56,7 +56,7 @@ Replaces: ngcp-mediaproxy-ng
 Description: NGCP RTP/media proxy - meta package.
  This is a meta package for easy installation of all four parts of the NGCP
  media proxy. It will install the user-space daemon, the kernel-space IPtables
- module, the IPtables extension module and utility scripts. 
+ module, the IPtables extension module and utility scripts.
 
 Package: ngcp-rtpengine-kernel-source
 Architecture: all

--- a/debian/ngcp-rtpengine-daemon.install
+++ b/debian/ngcp-rtpengine-daemon.install
@@ -1,3 +1,3 @@
 daemon/rtpengine /usr/sbin/
-recording-daemon/rtpengine-recording /usr/sbin/
 etc/rtpengine.sample.conf /etc/rtpengine/
+recording-daemon/rtpengine-recording /usr/sbin/

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -3,6 +3,7 @@
 #include <libavformat/avformat.h>
 #include <libavutil/audio_fifo.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/mathematics.h>
 #include <glib.h>
 #include <stdint.h>
 #include <libavresample/avresample.h>
@@ -378,7 +379,12 @@ void decoder_close(decoder_t *dec) {
 	if (!dec)
 		return;
 	/// XXX drain inputs and outputs
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 1, 0)
 	avcodec_free_context(&dec->avcctx);
+#else
+	avcodec_close(dec->avcctx);
+	av_free(dec->avcctx);
+#endif
 	av_frame_free(&dec->frame);
 	av_frame_free(&dec->swr_frame);
 	avresample_free(&dec->avresample);

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -4,6 +4,7 @@
 #include <libavfilter/buffersrc.h>
 #include <libavfilter/buffersink.h>
 #include <libavutil/channel_layout.h>
+#include <libavutil/mathematics.h>
 #include <inttypes.h>
 #include <libavresample/avresample.h>
 #include <libavutil/opt.h>


### PR DESCRIPTION
The recording feature seems to require a minimal version of libav related packages.
Tested on Wheezy and Jessie. 