### PR TITLE
Update rtpengine.init

### DIFF
--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -208,7 +208,7 @@ start() {
 		else
 			iptables -N rtpengine
 			# We insert the rtpengine rule at the top of the input chain
-			iptables -t filter -I INPUT_prefilter -j rtpengine
+			iptables -t filter -I INPUT -j rtpengine
 			iptables -I rtpengine -p udp -j RTPENGINE --id $TABLE
 			ip6tables -I rtpengine -p udp -j RTPENGINE --id $TABLE
 		fi


### PR DESCRIPTION
There is no INPUT_prefilter table on CentOS 6 systems.  So put it on INPUT should be good enough.