### PR TITLE
base64: flush base64 decoding, and skip base64 padding in crypto line

### DIFF
--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -446,10 +446,9 @@ static int parse_attribute_crypto(struct sdp_attribute *output) {
 			(guchar *) c->key_salt_buf, &b64_state, &b64_save);
         // flush b64_state needed for AES-192: 36+2; AES-256: 45+1;
         if (enc_salt_key_len % 4) {
-                ret += g_base64_decode_step("==", 4 - b64_state,
+                ret += g_base64_decode_step("==", 4 - (enc_salt_key_len % 4),
                         (guchar *) c->key_salt_buf + ret, &b64_state, &b64_save);
         }
-        assert( !b64_state );
 	err = "invalid base64 encoding";
 	if (ret != salt_key_len)
 		goto error;


### PR DESCRIPTION
Tweak base64:
- in case key length + salt length is not a multiple of 3, e.g., AES-192, AES-256
- skip base64 padding ("==" or "=") 