### PR TITLE
make cli_incoming accept multiple connections

### DIFF
--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -840,7 +840,6 @@ next:
    nfd = accept(fd, (struct sockaddr *) &sin, &sinl);
    if (nfd == -1) {
        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-           ilog(LOG_INFO, "Could currently not accept CLI commands. Reason:%s", strerror(errno));
            goto cleanup2;
        }
        ilog(LOG_INFO, "Accept error:%s", strerror(errno));
@@ -893,6 +892,8 @@ next:
 
 cleanup:
    close(nfd);
+   /* in case multiple incoming connections exist, read all of them */
+   goto next;
 cleanup2:
    mutex_unlock(&cli->lock);
    log_info_clear();


### PR DESCRIPTION
fixes #280 
The original problem in this issue is generated because multiple incoming connections on the listening socket can generate a single epoll event. Since the events have EPOLLET flag this means that if only one connection is treated (as with the code before) the other ones will never be processed, because no other event will be generated for them. If this happens some incoming connections will never be treated and the client will never get a response (this is why the rtpengine-ctl client never prints and remains hanged).  
Modifications to the cli_incoming function will allow to treat all connections, since now accept is called until it returns EAGAIN || EWOULDBLOCK. 



