### PR TITLE
Interop: document libsrtp AES-256 SRTCP bug

### DIFF
--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -448,6 +448,18 @@ int crypto_gen_session_key(struct crypto_context *c, str *out, unsigned char lab
 	return 0;
 }
 
+/*
+ * All versions of libsrtp w/openssl prior to 1.6 and 2.1 have
+ * a bug in iv generation for AES-256 SRTCP only (SRTP is ok).
+ * https://github.com/cisco/libsrtp/issues/264
+ * Example: FreeSWITCH 1.6.x.
+ * The bug is equivalent to:
+ *
+ * // idx <= 16 - no left shift
+ * // ivi[1] ^= ssrc - don't use ssrc
+ * // ivi[2] ^= idxh - don't use idxh
+ */
+
 /* rfc 3711 section 4.1.1 */
 static int aes_cm_encrypt(struct crypto_context *c, u_int32_t ssrc, str *s, u_int64_t idx) {
 	unsigned char iv[16];


### PR DESCRIPTION
Document a mild interop issue due to a bug that is in libsrtp+OpenSSL SRTCP AES-256 CM that exists in all libsrtp versions in the wild. This bug is to be fixed in libsrtp 1.6 and 2.1. Versions of libsrtp compiled without OpenSSL support are unaffected.

This interop issue is mild and only affects SRTCP AES-256. Both SRTP and SRTCP AES-128 are unaffected.

E.g., encountered with rtpengine<-->FreeSWITCH 1.6.15 as conference bridge with AES-256 CM.
https://github.com/cisco/libsrtp/issues/264