### PR TITLE
Issue354: Fix for rtpengint to ngcp-rtpengine renaming issues

### DIFF
--- a/el/rtpengine.init
+++ b/el/rtpengine.init
@@ -31,7 +31,7 @@ rtpengine=/usr/sbin/rtpengine
 prog=rtpengine
 pidfile=${PIDFILE-/var/run/rtpengine.pid}
 lockfile=${LOCKFILE-/var/lock/subsys/rtpengine}
-cachefile=/var/lib/rtpengine/rtpengine.cfg
+cachefile=/var/lib/ngcp-rtpengine/rtpengine.cfg
 RETVAL=0
 
 OPTS="--pidfile $pidfile"

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -88,8 +88,8 @@ install -D -p -m644 kernel-module/xt_RTPENGINE.h \
 mkdir -p %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}
 install -D -p -m644 kernel-module/rtpengine_config.h \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/rtpengine_config.h
-sed -i -e "s/__VERSION__/%{version}-%{release}/g;s/ngcp-rtpengine/rtpengine/g" debian/dkms.conf.in
 install -D -p -m644 debian/dkms.conf.in %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
+sed -i -e "s/__VERSION__/%{version}-%{release}/g" %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
 
 # For RHEL 7, load the compiled kernel module on boot.
 %if 0%{?rhel} == 7

--- a/el/rtpengine.sysconfig
+++ b/el/rtpengine.sysconfig
@@ -41,6 +41,6 @@ LISTEN_UDP=127.0.0.1:2222	# IP address and port combination for UDP
 #REDIS_DB=0
 #B2B_URL=http://127.0.0.1:8080/xmlrpc
 
-#RE_USER=rtpengine	# Run rtpengine as this specific user
+#RE_USER=ngcp-rtpengine	# Run rtpengine as this specific user
 
-#RE_GROUP=rtpengine	# allow this group to control rtpengine in kernel mode
+#RE_GROUP=ngcp-rtpengine # allow this group to control rtpengine in kernel mode


### PR DESCRIPTION
Some time ago rtpengine service was renamed to ngcp-rtpengine during rpm package installation. However some names were not renamed and were forgotten. That lead to installation issues and prevent from successfull packages install and running. This fix also includes fix of issue 356.
Note also that from my point of view it would be better to update dkms.conf file in the target rpmbuild/BUILDROOT directory instead doing that inside source rpmbuild/BUILD directory. Sometimes rpm packages are built from sources taken from some repository but not from tar file in rpmbuild/SOURCES dir. So keeping source file untouched is useful. That is why I propose to execute sed on file in the buildroot dir.