### PR TITLE
don't log corrupted cdr for foreign calls

### DIFF
--- a/daemon/cdr.c
+++ b/daemon/cdr.c
@@ -214,11 +214,8 @@ void cdr_update_entry(struct call* c) {
 			if (_log_facility_cdr)
 			    ++cdrlinecnt;
 		}
+		/* log it */
+		cdrlog(cdrbuffer);
 	}
-
-	/* log it */
-	cdrlog(cdrbuffer);
-
-
 }
 


### PR DESCRIPTION
 cdrbuffer is not initialized unless IS_OWN_CALL is true, so only log it in that case