### PR TITLE
Stop recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ a string and determines the type of message. Currently the following commands ar
 * delete
 * query
 * start recording
+* stop recording
 
 The response dictionary must contain at least one key called `result`. The value can be either `ok` or `error`.
 For the `ping` command, the additional value `pong` is allowed. If the result is `error`, then another key
@@ -1413,3 +1414,11 @@ call legs, therefore all keys other than `call-id` are currently ignored.
 
 If the chosen recording method doesn't support in-kernel packet forwarding, enabling call recording
 via this messages will force packet forwarding to happen in userspace only.
+
+`stop recording` Message
+-------------------------
+
+The `stop recording` message must contain the key `call-id` as defined above. The reply dictionary contains
+no additional keys.
+
+Disables call recording for the call. This can be sent during a call to imediatley stop recording it.

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1121,3 +1121,21 @@ const char *call_start_recording_ng(bencode_item_t *input, struct callmaster *m,
 
 	return NULL;
 }
+
+const char *call_stop_recording_ng(bencode_item_t *input, struct callmaster *m, bencode_item_t *output) {
+	str callid;
+	struct call *call;
+
+	if (!bencode_dictionary_get_str(input, "call-id", &callid))
+		return "No call-id in message";
+	call = call_get_opmode(&callid, m, OP_OTHER);
+	if (!call)
+		return "Unknown call-id";
+
+	recording_stop(call);
+
+	rwlock_unlock_w(&call->master_lock);
+	obj_put(call);
+
+	return NULL;
+}

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -185,7 +185,7 @@ static void cli_incoming_list_totals(char* buffer, int len, struct callmaster* m
 	}
 	for (GList *l = list; l; l = l->next) {
 		struct control_ng_stats* cur = l->data;
-		printlen = snprintf(replybuffer,(outbufend-replybuffer), " %20s | %10u | %10u | %10u | %10u | %10u | %10u | %10u | %10u \n",
+		printlen = snprintf(replybuffer,(outbufend-replybuffer), " %20s | %10u | %10u | %10u | %10u | %10u | %10u | %10u | %10u | %10u \n",
 				sockaddr_print_buf(&cur->proxy),
 				cur->offer,
 				cur->answer,
@@ -194,6 +194,7 @@ static void cli_incoming_list_totals(char* buffer, int len, struct callmaster* m
 				cur->list,
 				cur->query,
 				cur->start_recording,
+				cur->stop_recording,
 				cur->errors);
 		ADJUSTLEN(printlen,outbufend,replybuffer);
 	}

--- a/daemon/control_ng.c
+++ b/daemon/control_ng.c
@@ -229,6 +229,10 @@ static void control_ng_incoming(struct obj *obj, str *buf, const endpoint_t *sin
 		errstr = call_start_recording_ng(dict, c->callmaster, resp);
 		g_atomic_int_inc(&cur->start_recording);
 	}
+	else if (!str_cmp(&cmd, "stop recording")) {
+		errstr = call_stop_recording_ng(dict, c->callmaster, resp);
+		g_atomic_int_inc(&cur->stop_recording);
+	}
 	else
 		errstr = "Unrecognized command";
 

--- a/daemon/control_ng.h
+++ b/daemon/control_ng.h
@@ -19,6 +19,7 @@ struct control_ng_stats {
 	int query;
 	int list;
 	int start_recording;
+	int stop_recording;
 	int errors;
 };
 


### PR DESCRIPTION
Add stop recording message to ng control interface. This can be sent to rtpengine to stop recording while call is ongoing.