### PR TITLE
check call.recording structure before using it

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1527,7 +1527,7 @@ static void json_restore_call(struct redis *r, struct callmaster *m, const str *
 	if (!redis_hash_get_str(&s, &call, "recording_meta_prefix")) {
 		recording_start(c, s.s);
 
-		if (!redis_hash_get_str(&s, &call, "recording_metadata"))
+		if ((c->recording) && (!redis_hash_get_str(&s, &call, "recording_metadata")))
 			call_str_cpy(c, &c->recording->metadata, &s);
 	}
 


### PR DESCRIPTION
if call recording is not configured but the Redis db contains calls with recording flag, then call.recording can be NULL. This can happen if  two rtpengines are configured with redundancy using Redis, but only one has call recording configured.