### PR TITLE
Add recording forwarding

### DIFF
--- a/daemon/recording.h
+++ b/daemon/recording.h
@@ -113,9 +113,9 @@ void recording_fs_init(const char *spooldir, const char *method, const char *for
  *
  * Returns a boolean for whether or not the call is being recorded.
  */
-void detect_setup_recording(struct call *call, const str *recordcall);
+void detect_setup_recording(struct call *call, const str *recordcall, str *metadata);
 
-void recording_start(struct call *call, const char *);
+void recording_start(struct call *call, const char *prefix, str *metadata);
 void recording_stop(struct call *call);
 
 

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1440,7 +1440,7 @@ static void json_restore_call(struct redis *r, struct callmaster *m, const str *
 	struct redis_hash call;
 	struct redis_list tags, sfds, streams, medias, maps;
 	struct call *c = NULL;
-	str s, id;
+	str s, id, meta;
 
 	const char *err = 0;
 	int i;
@@ -1547,10 +1547,8 @@ static void json_restore_call(struct redis *r, struct callmaster *m, const str *
 
 	// presence of this key determines whether we were recording at all
 	if (!redis_hash_get_str(&s, &call, "recording_meta_prefix")) {
-		recording_start(c, s.s);
-
-		if ((c->recording) && (!redis_hash_get_str(&s, &call, "recording_metadata")))
-			call_str_cpy(c, &c->recording->metadata, &s);
+		redis_hash_get_str(&meta, &call, "recording_metadata");
+		recording_start(c, s.s, &meta);
 	}
 
 	err = NULL;

--- a/recording-daemon/Makefile
+++ b/recording-daemon/Makefile
@@ -25,7 +25,7 @@ LDFLAGS+=	`mysql_config --libs`
 include ../lib/lib.Makefile
 
 SRCS=		epoll.c garbage.c inotify.c main.c metafile.c stream.c recaux.c packet.c \
-		decoder.c output.c mix.c resample.c db.c log.c
+		decoder.c output.c mix.c resample.c db.c log.c forward.c
 LIBSRCS=	loglib.c auxlib.c rtplib.c
 OBJS=		$(SRCS:.c=.o) $(LIBSRCS:.c=.o)
 

--- a/recording-daemon/forward.c
+++ b/recording-daemon/forward.c
@@ -1,0 +1,71 @@
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <fcntl.h>
+#include "forward.h"
+#include "main.h"
+#include "log.h"
+
+void start_forwarding_capture(metafile_t *mf, char *meta_info) {
+	int sock;
+	struct sockaddr_un addr;
+
+	if (mf->forward_fd >= 0) {
+		ilog(LOG_INFO, "Connection already established");
+		return;
+	}
+
+	if ((sock = socket(AF_UNIX, SOCK_SEQPACKET, 0)) == -1) {
+		ilog(LOG_ERR, "Error creating socket: %s", strerror(errno));
+		return;
+	}
+
+	memset(&addr, 0, sizeof(addr));
+	addr.sun_family = AF_UNIX;
+	strncpy(addr.sun_path, forward_to, sizeof(addr.sun_path) - 1);
+
+	if (fcntl(sock, F_SETFL, O_NONBLOCK) < 0) {
+		ilog(LOG_ERR, "Error setting socket non-blocking: %s", strerror(errno));
+		goto err;
+	}
+
+	if (connect(sock, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+		ilog(LOG_ERR, "Error connecting to socket %s : %s", addr.sun_path,
+				strerror(errno));
+		goto err;
+	}
+
+	if (send(sock, meta_info, strlen(meta_info), 0) == -1) {
+		ilog(LOG_ERR, "Error sending meta info: %s. Call will not be forwarded", strerror(errno));
+		goto err;
+	}
+
+	mf->forward_fd = sock;
+	return;
+err:
+	close(sock);
+}
+
+int forward_packet(metafile_t *mf, unsigned char *buf, unsigned len) {
+
+	if (mf->forward_fd == -1) {
+		ilog(LOG_ERR,
+				"Trying to send packets, but connection not initialized!");
+		goto err;
+	}
+
+	if (send(mf->forward_fd, buf, len, 0) == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			ilog(LOG_DEBUG, "Dropping packet since call would block");
+		else
+			ilog(LOG_ERR, "Error sending: %s", strerror(errno));
+		goto err;
+	}
+
+	free(buf);
+	return 0;
+
+err:
+	free(buf);
+	return -1;
+}
+

--- a/recording-daemon/forward.h
+++ b/recording-daemon/forward.h
@@ -1,0 +1,9 @@
+#ifndef _FORWARD_H_
+#define _FORWARD_H_
+
+#include "types.h"
+
+void start_forwarding_capture(metafile_t *mf, char *meta_info);
+int forward_packet(metafile_t *mf, unsigned char *buf, unsigned len);
+
+#endif

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -8,11 +8,13 @@ extern const char *spool_dir;
 extern const char *output_dir;
 extern int output_mixed;
 extern int output_single;
+extern int output_enabled;
 extern const char *c_mysql_host,
       *c_mysql_user,
       *c_mysql_pass,
       *c_mysql_db;
 extern int c_mysql_port;
+extern const char *forward_to;
 
 extern volatile int shutdown_flag;
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -101,6 +101,10 @@ struct metafile_s {
 	mix_t *mix;
 	output_t *mix_out;
 
+	int forward_fd;
+	volatile gint forward_count;
+	volatile gint forward_failed;
+
 	pthread_mutex_t payloads_lock;
 	char *payload_types[128];
 };


### PR DESCRIPTION
These commits add the option for recording daemon to forward the captured traffic to a UNIX domain socket instead of encoding to wav/mp3 and saving an audio file.  We chose a UNIX domain socket because we can use the SOCK_SEQPACKET type which allows to make have a connection based communication, but uses datagrams instead of streams, so it will be easier to detect each individual RTP package. 
This way for each call a new connection is made and a simple program that listens on than UNIX domain socket can process each RTP packet from each stream, as needed. 

The first received message contains the metadata info in clear text format, so control information can easily be passed from rtpengine (or from kamailio by using start_recording() or rtpengine_manage()). 