### PR TITLE
don't use g_hash_table_foreach for call_timer_iterator

### DIFF
--- a/daemon/call.h
+++ b/daemon/call.h
@@ -536,5 +536,12 @@ INLINE struct packet_stream *packet_stream_sink(struct packet_stream *ps) {
 	return ret;
 }
 
+INLINE void call_obj_get(gpointer data, gpointer user_data) {
+	obj_get((struct call* )data);
+}
+INLINE void call_obj_put(gpointer data) {
+	obj_put((struct call* )data);
+}
+
 
 #endif


### PR DESCRIPTION
this keeps the callmaster->hashlock for a long time so copy the list of calls instead and update call refs