### PR TITLE
Replace transport protocol only if protocol was specified in flags

### DIFF
--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -1952,12 +1952,14 @@ int sdp_replace(struct sdp_chopper *chop, GQueue *sessions, struct call_monologu
 			ps = j->data;
 
 			if (!flags->ice_force_relay) {
-			        if (replace_media_port(chop, sdp_media, ps))
-				        goto error;
-			        if (replace_consecutive_port_count(chop, sdp_media, ps, j))
-				        goto error;
-				if (replace_transport_protocol(chop, sdp_media, call_media))
-				        goto error;
+				if (replace_media_port(chop, sdp_media, ps))
+					goto error;
+				if (replace_consecutive_port_count(chop, sdp_media, ps, j))
+					goto error;
+				if (flags->transport_protocol) {
+					if (replace_transport_protocol(chop, sdp_media, call_media))
+						goto error;
+				}
 
 				if (sdp_media->connection.parsed) {
 				        if (replace_network_address(chop, &sdp_media->connection.address, ps,


### PR DESCRIPTION
Setup: Polycom phone with SDES (optional) -- Kamailio + Rtpengine -- Asterisk PBX

On initial INVITE Polycom sends SDP with:
m=audio 2278 RTP/SAVP
m=audio 2278 RTP/AVP
m=video 2280 RTP/SAVP
m=video 2280 RTP/AVP

Kmailio calls rtpengine_manage() with flags:
"direction=pub direction=priv replace-origin replace-session-connection ICE=remove SDES-off"

INVITE passed to Asterisk with the same media options (different port numbers). Asterisk is configured only to accept audio RTP. Call is answered and media goes like:
Polycom -- SRTP -- rtpengine -- RTP -- Asterisk.

Now Polycom puts call on HOLD. That produce INVITE with SDP like:
m=audio 2278 RTP/SAVP
m=audio 2278 RTP/AVP
m=video 0 RTP/SAVP
m=video 0 RTP/AVP

At this point, by some reason, Rtpengine replaces transport protocol with RTP/AVP and Asterisk presented with such media options:
m=audio xxx RTP/AVP
m=audio xxx RTP/AVP
m=video 0 RTP/AVP
m=video 0 RTP/AVP
Multiple RTP/AVP for audio confuses the Asterisk and it rejects the INVITE with 488.


Patch in this pull request prevents protocol replacement if it wasn't set in "flags". 
It allows RE-INVITE to pass and present Asterisk valid media options:
m=audio xxx RTP/SAVP
m=audio xxx RTP/AVP
m=video 0 RTP/SAVP
m=video 0 RTP/AVP

This may potentially fix issues #275 and #393
