### PR TITLE
adding no-rtcp-filtering flag

### DIFF
--- a/daemon/call.h
+++ b/daemon/call.h
@@ -401,6 +401,8 @@ struct call {
 	unsigned int		foreign_call; // created_via_redis_notify call
 
 	struct recording 	*recording;
+
+	unsigned int	no_rtcp_filtering;
 };
 
 

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -610,6 +610,8 @@ static void call_ng_flags_flags(struct sdp_ng_flags *out, str *s, void *dummy) {
 		out->no_rtcp_attr = 1;
 	else if (!str_cmp(s, "loop-protect"))
 		out->loop_protect = 1;
+	else if (!str_cmp(s, "no-rtcp-filtering"))
+		out->no_rtcp_filtering = 1;
 	else {
 		// handle values aliases from other dictionaries
 		if (call_ng_flags_prefix(out, s, "SDES-", ng_sdes_option, NULL))
@@ -792,6 +794,9 @@ static const char *call_offer_answer_ng(bencode_item_t *input,
 		call->created_from = call_strdup(call, addr);
 		call->created_from_addr = sin->address;
 	}
+
+	call->no_rtcp_filtering = flags.no_rtcp_filtering?1:0;
+
 	/* At least the random ICE strings are contained within the call struct, so we
 	 * need to hold a ref until we're done sending the reply */
 	call_bencode_hold_ref(call, output);

--- a/daemon/call_interfaces.h
+++ b/daemon/call_interfaces.h
@@ -65,7 +65,8 @@ struct sdp_ng_flags {
 	    sdes_unauthenticated_srtp:1,
 	    sdes_encrypted_srtp:1,
 	    sdes_encrypted_srtcp:1,
-	    sdes_authenticated_srtp:1;
+	    sdes_authenticated_srtp:1,
+	    no_rtcp_filtering:1;
 };
 
 extern int trust_address_def;

--- a/daemon/rtcp.c
+++ b/daemon/rtcp.c
@@ -799,7 +799,7 @@ int rtcp_payload(struct rtcp_packet **out, str *p, const str *s, int no_rtcp_fil
 	if (rtcp->header.version != 2)
 		goto error;
 	err = "invalid packet type";
-	if (rtcp->header.pt != RTCP_PT_SR && rtcp->header.pt != RTCP_PT_RR
+	if (rtcp->header.pt != RTCP_PT_SR && rtcp->header.pt != RTCP_PT_RR && rtcp->header.pt != RTCP_PT_SDES
 		&& (!no_rtcp_filtering || (no_rtcp_filtering && rtcp->header.pt != RTCP_PT_RTPFB && rtcp->header.pt != RTCP_PT_PSFB)))
 		goto error;
 

--- a/daemon/rtcp.c
+++ b/daemon/rtcp.c
@@ -785,7 +785,7 @@ error:
 	return -1;
 }
 
-int rtcp_payload(struct rtcp_packet **out, str *p, const str *s) {
+int rtcp_payload(struct rtcp_packet **out, str *p, const str *s, int no_rtcp_filtering) {
 	struct rtcp_packet *rtcp;
 	const char *err;
 
@@ -799,8 +799,8 @@ int rtcp_payload(struct rtcp_packet **out, str *p, const str *s) {
 	if (rtcp->header.version != 2)
 		goto error;
 	err = "invalid packet type";
-	if (rtcp->header.pt != RTCP_PT_SR
-			&& rtcp->header.pt != RTCP_PT_RR)
+	if (rtcp->header.pt != RTCP_PT_SR && rtcp->header.pt != RTCP_PT_RR
+		&& (!no_rtcp_filtering || (no_rtcp_filtering && rtcp->header.pt != RTCP_PT_RTPFB && rtcp->header.pt != RTCP_PT_PSFB)))
 		goto error;
 
 	if (!p)
@@ -818,14 +818,14 @@ error:
 }
 
 /* rfc 3711 section 3.4 */
-int rtcp_avp2savp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx) {
+int rtcp_avp2savp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx, int no_rtcp_filtering) {
 	struct rtcp_packet *rtcp;
 	u_int32_t *idx;
 	str to_auth, payload;
 
 	if (G_UNLIKELY(!ssrc_ctx))
 		return -1;
-	if (rtcp_payload(&rtcp, &payload, s))
+	if (rtcp_payload(&rtcp, &payload, s, no_rtcp_filtering))
 		return -1;
 	if (check_session_keys(c))
 		return -1;
@@ -851,7 +851,7 @@ int rtcp_avp2savp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx) {
 
 
 /* rfc 3711 section 3.4 */
-int rtcp_savp2avp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx) {
+int rtcp_savp2avp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx, int no_rtcp_filtering) {
 	struct rtcp_packet *rtcp;
 	str payload, to_auth, to_decrypt, auth_tag;
 	u_int32_t idx, *idx_p;
@@ -860,7 +860,7 @@ int rtcp_savp2avp(str *s, struct crypto_context *c, struct ssrc_ctx *ssrc_ctx) {
 
 	if (G_UNLIKELY(!ssrc_ctx))
 		return -1;
-	if (rtcp_payload(&rtcp, &payload, s))
+	if (rtcp_payload(&rtcp, &payload, s, no_rtcp_filtering))
 		return -1;
 	if (check_session_keys(c))
 		return -1;

--- a/daemon/rtcp.h
+++ b/daemon/rtcp.h
@@ -23,10 +23,10 @@ struct rtcp_parse_ctx {
 extern struct rtcp_handler *rtcp_transcode_handler;
 
 
-int rtcp_avp2savp(str *, struct crypto_context *, struct ssrc_ctx *);
-int rtcp_savp2avp(str *, struct crypto_context *, struct ssrc_ctx *);
+int rtcp_avp2savp(str *, struct crypto_context *, struct ssrc_ctx *, int no_rtcp_filtering);
+int rtcp_savp2avp(str *, struct crypto_context *, struct ssrc_ctx *, int no_rtcp_filtering);
 
-int rtcp_payload(struct rtcp_packet **out, str *p, const str *s);
+int rtcp_payload(struct rtcp_packet **out, str *p, const str *s, int no_rtcp_filtering);
 
 int rtcp_parse(GQueue *q, struct media_packet *);
 void rtcp_list_free(GQueue *q);


### PR DESCRIPTION
Some SIP endpints rely on rtcp feedback messages despite usage of RTP/(S)AVP profile.
This change adds no-rtcp-filtering flag that disables rtcp feedback filtering on RTP/(S)AVP streams. 