### PR TITLE
recording.c: save the label in pcap metadata file

### DIFF
--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -350,6 +350,9 @@ static void sdp_after_pcap(struct recording *recording, GString *str, struct cal
 	// File pointers buffer data, whereas direct writing using the file
 	// descriptor does not. Make sure to flush any unwritten contents
 	// so the file contents appear in order.
+	if (ml->label.len) {
+		fprintf(meta_fp, "\nLabel: %*s", ml->label.len, ml->label.s);
+	}
 	fprintf(meta_fp, "\nSDP mode: ");
 	fprintf(meta_fp, "%s", get_opmode_text(opmode));
 	fprintf(meta_fp, "\nSDP before RTP packet: %" PRIu64 "\n\n", recording->u.pcap.packet_num);


### PR DESCRIPTION
label in ng-protocol can be used by SIP proxy to send additional metadata. It is useful to persist this data for CDR, audit etc.

I have a customer use case where it is useful to explicitly save the callid, from URI, to URI. For example: at proxy side
```
# kamailio
rtpengine_manage("label=$ci,$fu,$tu")
```
Although the callid is implicit in the metadata filename, this example is more explicit. The customer wishes to store metadata and pcap files to separate audit storage and would like to be able to correlate with CDRs easily.

