### PR TITLE
Fix AMR-WB codec initialisation

### DIFF
--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -300,7 +300,7 @@ static codec_def_t __codec_defs[] = {
 	},
 	{
 		.rtpname = "AMR-WB",
-		.avcodec_id = AV_CODEC_ID_AMR_NB,
+		.avcodec_id = AV_CODEC_ID_AMR_WB,
 		.avcodec_name = NULL,
 		.default_clockrate = 16000,
 		.default_channels = 1,


### PR DESCRIPTION
I was getting these errors when transcoding PCMA <=> AMR-WB:
Mar 13 15:33:34 EU1C11TESTSIPRTP03 rtpengine[4389]: ERR: [abc123@10.1.1.1 port 30190]: av_log: Only 8000Hz sample rate supported
Mar 13 15:33:34 EU1C11TESTSIPRTP03 rtpengine[4389]: ERR: [abc123@10.1.1.1 port 30190]: Error configuring media output for codec AMR-WB: failed to open output
and found a typo in the AMR-WB initialisation.

My session is now established, but I get other decoder errors and mangled audio. Separate investigation needed there.