### PR TITLE
Fix for recovering from losing synchronous redis context while the as…

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -346,6 +346,9 @@ void on_redis_notification(redisAsyncContext *actx, void *reply, void *privdata)
 	// now at <key>
 	callid = keyspace_id;
 
+	if (redis_check_conn(r) == REDIS_STATE_DISCONNECTED)
+		goto err;
+
 	// select the right db for restoring the call
 	if (redisCommandNR(r->ctx, "SELECT %i", r->db)) {
 		if (r->ctx && r->ctx->err)


### PR DESCRIPTION
…ync one is up

Force re-checking of the synchronous redis context state in case of processing
a redis notification. It is possible that redis async context is up while the
blocking one is down.