### PR TITLE
rtpengine-ctl params updates and additions

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -490,6 +490,7 @@ void fill_initial_rtpe_cfg(struct rtpengine_config* ini_rtpe_cfg) {
 	ini_rtpe_cfg->redis_disable_time = rtpe_config.redis_disable_time;
 	ini_rtpe_cfg->redis_cmd_timeout = rtpe_config.redis_cmd_timeout;
 	ini_rtpe_cfg->redis_connect_timeout = rtpe_config.redis_connect_timeout;
+	ini_rtpe_cfg->common.log_level = rtpe_config.common.log_level;
 
 	ini_rtpe_cfg->graphite_ep = rtpe_config.graphite_ep;
 	ini_rtpe_cfg->tcp_listen_ep = rtpe_config.tcp_listen_ep;

--- a/utils/rtpengine-ctl
+++ b/utils/rtpengine-ctl
@@ -114,6 +114,7 @@ sub showusage {
     print "         start                 : lists the initial values of all the configuration file parameters\n";
     print "         current               : lists the present values of all the configuration file parameters\n";
     print "         diff                  : compares initial and present values of all the configuration file parameters and lists the updated parameters\n";
+    print "         revert                : reverts the values of all the configuration file parameters to their initial values\n";
     print "\n";
     print "    ksadd [ keyspace <uint>]\n";
     print "         keyspace <uint>       : subscribe to 'keyspace' database\n";


### PR DESCRIPTION
-cli params diff command has been updated to serve only for the possible modifiable configuration file parameters (max_sessions, timeout, silent_timeout, final_timeout, log_level, redis_allowed_errors, redis_disable_time, redis_connect_timeout, control_tos).
-Additionally, cli params revert command has been implemented.