### PR TITLE
do not require epel-release in spec file

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -42,8 +42,8 @@ Group:		System Environment/Daemons
 BuildArch:	noarch
 BuildRequires:	redhat-rpm-config
 Requires:	gcc make
-Requires(post):	epel-release dkms
-Requires(preun): epel-release dkms
+Requires(post):	dkms
+Requires(preun): dkms
 
 %description dkms
 %{summary}.


### PR DESCRIPTION
Update the spec file so that it does not pull in epel-release.  This allows those who maintain their own repositories to keep things untainted.