### PR TITLE
Make recording more accurately report source address

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -1648,7 +1648,7 @@ static int stream_packet(struct packet_handler_ctx *phc) {
 
 	// If recording pcap dumper is set, then we record the call.
 	if (phc->mp.call->recording)
-		dump_packet(phc->mp.call->recording, phc->mp.stream, &phc->s);
+		dump_packet(&phc->mp, &phc->s);
 
 	// ready to process
 

--- a/include/recording.h
+++ b/include/recording.h
@@ -18,6 +18,7 @@
 
 
 struct packet_stream;
+struct media_packet;
 struct call;
 enum call_opmode;
 struct rtpengine_target_info;
@@ -71,7 +72,7 @@ struct recording_method {
 			enum call_opmode);
 	void (*meta_chunk)(struct recording *, const char *, const str *);
 
-	void (*dump_packet)(struct recording *, struct packet_stream *sink, const str *s);
+	void (*dump_packet)(struct media_packet *, const str *s);
 	void (*finish)(struct call *);
 	void (*response)(struct recording *, bencode_item_t *);
 


### PR DESCRIPTION
Just as a note. I have tested the pcap recording method, but not the proc recording method. I tried to make the commit as unintrusive as possible and I expect that proc recording works as it should.