### PR TITLE
update rtpengine-recording pid filename

### DIFF
--- a/el/rtpengine-recording.sysconfig
+++ b/el/rtpengine-recording.sysconfig
@@ -2,7 +2,7 @@
 # http://github.com/sipwise/rtpengine
 #
 CONFIG_FILE=/etc/rtpengine/rtpengine-recording.conf
-PIDFILE=/var/run/ngcp-rtpengine-recording-daemon.pid
+PIDFILE=/var/run/rtpengine-recording.pid
 #SET_USER=root
 #SET_GROUP=root	# GROUP only needs to be set if USER is not set or if the user isn't in the group
 


### PR DESCRIPTION
sysinit script is not expected to see /var/run/ngcp-rtpengine-recording-daemon.pid 
PID file name renamed to rtpengine-recording.pid