### PR TITLE
Fix homer and add Graphite to el sysconfig

### DIFF
--- a/el/rtpengine.sysconfig
+++ b/el/rtpengine.sysconfig
@@ -36,7 +36,7 @@ CONFIG_FILE=/etc/rtpengine/rtpengine.conf # main config file
 #SET_USER=ngcp-rtpengine	# Run rtpengine as this specific user
 #SET_GROUP=ngcp-rtpengine	# allow this group to control rtpengine in kernel mode
 
-#HOMER_SERVER=127.0.0.1:9060	# Address of Homer server for RTCP stats
+#HOMER=127.0.0.1:9060	# Address of Homer server for RTCP stats
 #HOMER_PROTO=udp		# Transport protocol for Homer (default udp)
-#HOMER_CAPTURE_ID=1234		# 'Capture ID' to use within the HEP protocol
+#HOMER_ID=1234		# 'Capture ID' to use within the HEP protocol
 

--- a/el/rtpengine.sysconfig
+++ b/el/rtpengine.sysconfig
@@ -40,3 +40,6 @@ CONFIG_FILE=/etc/rtpengine/rtpengine.conf # main config file
 #HOMER_PROTO=udp		# Transport protocol for Homer (default udp)
 #HOMER_ID=1234		# 'Capture ID' to use within the HEP protocol
 
+#GRAPHITE=127.0.0.1:2003    # TCP address of graphite statistics server
+#GRAPHITE_INTERVAL=60       # Graphite data statistics send interval
+#GRAPHITE_PREFIX=STRING     # Graphite prefix for every line


### PR DESCRIPTION
The el init script and sysconfig is out of sync, so fix the sysconfig script to use the current variables.

While here add options for Graphite.