### PR TITLE
Option to write SRTP keys to error log

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ option and which are reproduced below:
 	  --priority=INT                   Thread scheduling priority
 	  --idle-scheduling=default|...    Idle thread scheduling policy
 	  --idle-priority=INT              Idle thread scheduling priority
-          --log-rtp-keys                   Write SRTP keys to log
+        --log-srtp-keys                   Write SRTP keys to log
 
 Most of these options are indeed optional, with two exceptions. It's mandatory to specify at least one local
 IP address through `--interface`, and at least one of the `--listen-...` options must be given.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ option and which are reproduced below:
 	  --priority=INT                   Thread scheduling priority
 	  --idle-scheduling=default|...    Idle thread scheduling policy
 	  --idle-priority=INT              Idle thread scheduling priority
+          --log-rtp-keys                   Write SRTP keys to log
 
 Most of these options are indeed optional, with two exceptions. It's mandatory to specify at least one local
 IP address through `--interface`, and at least one of the `--listen-...` options must be given.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ option and which are reproduced below:
 	  --priority=INT                   Thread scheduling priority
 	  --idle-scheduling=default|...    Idle thread scheduling policy
 	  --idle-priority=INT              Idle thread scheduling priority
-        --log-srtp-keys                   Write SRTP keys to log
+	  --log-srtp-keys                  Write SRTP keys to error log instead of debug log
 
 Most of these options are indeed optional, with two exceptions. It's mandatory to specify at least one local
 IP address through `--interface`, and at least one of the `--listen-...` options must be given.

--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -14,6 +14,7 @@
 #include "log.h"
 #include "rtplib.h"
 #include "rtcplib.h"
+#include "main.h"
 
 
 
@@ -699,7 +700,7 @@ static int null_crypt_rtcp(struct crypto_context *c, struct rtcp_packet *r, str 
 	return 0;
 }
 
-static void dump_key(struct crypto_context *c) {
+static void dump_key(struct crypto_context *c, int log_level) {
 	char *k, *s;
 
 	if (!c->params.crypto_suite)
@@ -708,20 +709,25 @@ static void dump_key(struct crypto_context *c) {
 	k = g_base64_encode(c->params.master_key, c->params.crypto_suite->master_key_len);
 	s = g_base64_encode(c->params.master_salt, c->params.crypto_suite->master_salt_len);
 
-	ilog(LOG_DEBUG, "--- %s key %s salt %s", c->params.crypto_suite->name, k, s);
+	ilog(log_level, "--- %s key %s salt %s", c->params.crypto_suite->name, k, s);
 
 	g_free(k);
 	g_free(s);
 }
 
 void crypto_dump_keys(struct crypto_context *in, struct crypto_context *out) {
-	if (get_log_level() < LOG_DEBUG)
+	int log_level = LOG_DEBUG;
+	
+	if (rtpe_config.log_keys)
+	    log_level = LOG_ERROR;
+	    
+	if (get_log_level() < log_level)
 		return;
 
-	ilog(LOG_DEBUG, "SRTP keys, incoming:");
-	dump_key(in);
-	ilog(LOG_DEBUG, "SRTP keys, outgoing:");
-	dump_key(out);
+	ilog(log_level, "SRTP keys, incoming:");
+	dump_key(in, log_level);
+	ilog(log_level, "SRTP keys, outgoing:");
+	dump_key(out, log_level);
 }
 
 void crypto_init_main() {

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -362,7 +362,7 @@ static void options(int *argc, char ***argv) {
 		{ "priority",	0, 0,	G_OPTION_ARG_INT,	&rtpe_config.priority,	"Thread scheduling priority",	"INT" },
 		{ "idle-scheduling",0, 0,G_OPTION_ARG_STRING,	&rtpe_config.idle_scheduling,"Idle thread scheduling policy",	"default|none|fifo|rr|other|batch|idle" },
 		{ "idle-priority",0, 0,	G_OPTION_ARG_INT,	&rtpe_config.idle_priority,"Idle thread scheduling priority",	"INT" },
-		{ "log-rtp-keys",'F', 0, G_OPTION_ARG_NONE,	&rtpe_config.log_keys,	"Log rtp keys", NULL },
+		{ "log-srtp-keys",'F', 0, G_OPTION_ARG_NONE,	&rtpe_config.log_keys,	"Log SRTP keys", NULL },
 		{ NULL, }
 	};
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -362,7 +362,7 @@ static void options(int *argc, char ***argv) {
 		{ "priority",	0, 0,	G_OPTION_ARG_INT,	&rtpe_config.priority,	"Thread scheduling priority",	"INT" },
 		{ "idle-scheduling",0, 0,G_OPTION_ARG_STRING,	&rtpe_config.idle_scheduling,"Idle thread scheduling policy",	"default|none|fifo|rr|other|batch|idle" },
 		{ "idle-priority",0, 0,	G_OPTION_ARG_INT,	&rtpe_config.idle_priority,"Idle thread scheduling priority",	"INT" },
-		{ "log-srtp-keys",'F', 0, G_OPTION_ARG_NONE,	&rtpe_config.log_keys,	"Log SRTP keys", NULL },
+		{ "log-srtp-keys",'F', 0, G_OPTION_ARG_NONE,	&rtpe_config.log_keys,	"Log SRTP keys to error log", NULL },
 		{ NULL, }
 	};
 

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -362,6 +362,7 @@ static void options(int *argc, char ***argv) {
 		{ "priority",	0, 0,	G_OPTION_ARG_INT,	&rtpe_config.priority,	"Thread scheduling priority",	"INT" },
 		{ "idle-scheduling",0, 0,G_OPTION_ARG_STRING,	&rtpe_config.idle_scheduling,"Idle thread scheduling policy",	"default|none|fifo|rr|other|batch|idle" },
 		{ "idle-priority",0, 0,	G_OPTION_ARG_INT,	&rtpe_config.idle_priority,"Idle thread scheduling priority",	"INT" },
+		{ "log-rtp-keys",'F', 0, G_OPTION_ARG_NONE,	&rtpe_config.log_keys,	"Log rtp keys", NULL },
 		{ NULL, }
 	};
 

--- a/include/main.h
+++ b/include/main.h
@@ -76,6 +76,7 @@ struct rtpengine_config {
 	int			priority;
 	char			*idle_scheduling;
 	int			idle_priority;
+	int			log_keys;
 };
 
 


### PR DESCRIPTION
We recently had a problem where some calls from users would have choppy sound some times.
To make sure the problem was not related to any systems on our end I had to listen to the audio as it was coming in. If I set the log level high enough to log the keys I loose most of the logs to throttling so it's very useful to log the keys to the error log