### PR TITLE
Fix lower or higher target CentOS Kernel Versions

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -72,10 +72,6 @@ BuildRequires:  gcc make redhat-rpm-config mysql-devel ffmpeg-devel
 %define binname rtpengine
 %define archname rtpengine-mr
 
-%{!?kversion: %define kversion %(uname -r)}
-# hint: this can be overridden with "--define kversion foo" on rpmbuild,
-# e.g. --define "kversion 2.6.32-696.23.1.el6.x86_64"
-
 %prep
 %setup -q -n %{archname}%{version}
 
@@ -169,8 +165,8 @@ fi
 %post dkms
 # Add to DKMS registry, build, and install module
 dkms add -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
-dkms build -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade &&
-dkms install -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade --force
+dkms build -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
+dkms install -m %{name} -v %{version}-%{release} --rpm_safe_upgrade --force
 true
 
 


### PR DESCRIPTION
The changes in https://github.com/sipwise/rtpengine/commit/62ec9cc4d28fafac6a4937dccebfe2f852a77aec breaks the installation of ngcp-rtpengine-dkms. It will not produce any kind of xt_RTPENGINE.* module if your kernel-version dont match with the build-host. Only chance is if you have the *same* kernel-version as the build-host.
More is less here. Remove this changes.