### PR TITLE
rtpengine.spec: fix building dkms module on a different host kernel ver

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -72,9 +72,6 @@ BuildRequires:  gcc make redhat-rpm-config mysql-devel ffmpeg-devel
 %define binname rtpengine
 %define archname rtpengine-mr
 
-%{!?kversion: %define kversion %(uname -r)}
-# hint: this can be overridden with "--define kversion foo" on rpmbuild,
-# e.g. --define "kversion 2.6.32-696.23.1.el6.x86_64"
 
 %prep
 %setup -q -n %{archname}%{version}
@@ -168,9 +165,19 @@ fi
 
 %post dkms
 # Add to DKMS registry, build, and install module
-dkms add -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
-dkms build -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade &&
-dkms install -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade --force
+# The kernel version can be overridden with "--define kversion foo" on rpmbuild,
+# e.g. --define "kversion 2.6.32-696.23.1.el6.x86_64"
+%{!?kversion: %define kversion %{nil}}
+
+%if "%{kversion}" != ""
+  dkms add -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
+  dkms build -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade &&
+  dkms install -m %{name} -v %{version}-%{release} -k %{kversion} --rpm_safe_upgrade --force
+%else
+  dkms add -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
+  dkms build -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
+  dkms install -m %{name} -v %{version}-%{release} --rpm_safe_upgrade --force
+%endif
 true
 
 


### PR DESCRIPTION
fixes commit 62ec9cc
In case when DKMS package built without defined kversion, it must build module for target host current kernel version.