### PR TITLE
add kernel-devel package as requires for DKMS module build on a target host

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -50,7 +50,11 @@ Summary:	Kernel module for NGCP rtpengine in-kernel packet forwarding
 Group:		System Environment/Daemons
 BuildArch:	noarch
 BuildRequires:	redhat-rpm-config
-Requires:	gcc make kernel-devel
+Requires:	gcc make
+# Define requires according to the installed kernel.
+%{?rhel:Requires: kernel-devel}
+%{?fedora:Requires: kernel-devel}
+%{?suse_version:Requires: kernel-source}
 Requires(post):	dkms
 Requires(preun): dkms
 

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -50,7 +50,7 @@ Summary:	Kernel module for NGCP rtpengine in-kernel packet forwarding
 Group:		System Environment/Daemons
 BuildArch:	noarch
 BuildRequires:	redhat-rpm-config
-Requires:	gcc make
+Requires:	gcc make kernel-devel
 Requires(post):	dkms
 Requires(preun): dkms
 


### PR DESCRIPTION
DKMS module will not builded without kernel sources on the target host