### PR TITLE
add missing errno include

### DIFF
--- a/include/dtmf.h
+++ b/include/dtmf.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include <glib.h>
+#include <errno.h>
 #include "str.h"
 
 


### PR DESCRIPTION
Compilation error when trying to compile with "with_transcoding = no" switch.
> In file included from ./log.h:6:0,
>                  from ../include/obj.h:90,
>                  from ../include/media_socket.h:9,
>                  from dtmf.c:2:
> dtmf.c: In function 'dtmf_init':
> dtmf.c:15:77: error: 'errno' undeclared (first use in this function)
>     ilog(LOG_ERR, "Failed to open/connect DTMF logging socket: %s", strerror(errno));