### PR TITLE
dtmf: prevent freeing json buf too early

### DIFF
--- a/daemon/dtmf.c
+++ b/daemon/dtmf.c
@@ -82,6 +82,7 @@ int dtmf_event(struct media_packet *mp, str *payload, int clockrate) {
 			dtmflog(buf);
 		if (dtmf_log_sock.family)
 			send(dtmf_log_sock.fd, buf->str, buf->len, 0);
+		g_string_free(buf, TRUE);
 
 		ret = 1; // END event
 	}

--- a/daemon/log.c
+++ b/daemon/log.c
@@ -125,7 +125,6 @@ void dtmflog(GString *s) {
 	if (_log_facility_dtmf) {
 		syslog(LOG_INFO | _log_facility_dtmf, "%s", s->str);
 	}
-	g_string_free(s, TRUE);
 }
 
 


### PR DESCRIPTION
When both logging and sending the DTMF event further, the json buffer
was released/freed _before_ being sent on the network, resulting in a
0-length UDP packet. On the other hand, if only UDP sending was used
(without logging), a leak was happening. This commit fixes both issues.