### PR TITLE
RPM packaging on EL: detect systemd directories and package unit files

### DIFF
--- a/el/rtpengine-recording.service
+++ b/el/rtpengine-recording.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=NGCP RtpEngine - RTP Recording Daemon
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=forking
+User=ngcp-rtpengine
+Group=daemon
+Environment=CFGFILE=/etc/rtpengine/rtpengine-recording.conf
+EnvironmentFile=/etc/sysconfig/rtpengine-recording
+PIDFile=/var/run/rtpengine-recording.pid
+ExecStart=/usr/sbin/rtpengine-recording --config-file=${CFGFILE} --pidfile=$PIDFILE
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
For EL-like systems, using el/rtpengine.spec, package el/rtpengine.service and idiomatic usage of systemctl.