### PR TITLE
Add missing errno.h

### DIFF
--- a/daemon/dtmf.c
+++ b/daemon/dtmf.c
@@ -7,6 +7,7 @@
 #include "rtplib.h"
 #include "codec.h"
 #include "ssrc.h"
+#include "errno.h"
 
 
 


### PR DESCRIPTION
Fixes the following compilation error:

dtmf.c: In function 'dtmf_init':
dtmf.c:15:77: error: 'errno' undeclared (first use in this function)
    ilog(LOG_ERR, "Failed to open/connect DTMF logging socket: %s", strerror(errno));