### PR TITLE
Support zero-knowledge scaling of RTPEngine

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2018,6 +2018,11 @@ init:
 		ice_update(media->ice_agent, NULL); /* this is in case rtcp-mux has changed */
 
 		recording_setup_media(media);
+		
+		if (!call->rtpe_connection_addr.len) {
+			call->rtpe_connection_addr.s = call_malloc(call, 64);
+			format_network_address(&call->rtpe_connection_addr, media->streams.head->data, flags, 0);
+		}
 	}
 
 	return 0;

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1945,3 +1945,13 @@ int call_interfaces_init() {
 
 	return 0;
 }
+
+
+void format_network_address(str* o, struct packet_stream *ps, struct sdp_ng_flags *flags, int keep_unspec) {
+	if (!is_addr_unspecified(&flags->parsed_media_address))
+		o->len = sprintf(o->s, "%s %s",
+						 flags->parsed_media_address.family->rfc_name,
+						 sockaddr_print_buf(&flags->parsed_media_address));
+	else
+		call_stream_address46(o->s, ps, SAF_NG, &o->len, NULL, keep_unspec);
+}

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1952,6 +1952,8 @@ void format_network_address(str* o, struct packet_stream *ps, struct sdp_ng_flag
 		o->len = sprintf(o->s, "%s %s",
 						 flags->parsed_media_address.family->rfc_name,
 						 sockaddr_print_buf(&flags->parsed_media_address));
+	else if (IS_FOREIGN_CALL(ps->call) && ps->call->rtpe_connection_addr.len)
+		o->len = sprintf(o->s, "%s", ps->call->rtpe_connection_addr.s);
 	else
 		call_stream_address46(o->s, ps, SAF_NG, &o->len, NULL, keep_unspec);
 }

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1596,6 +1596,8 @@ static void json_restore_call(struct redis *r, const str *callid, enum call_type
 		c->created_from = call_strdup(c, id.s);
 	if (!redis_hash_get_str(&id, &call, "created_from_addr"))
 		sockaddr_parse_any_str(&c->created_from_addr, &id);
+	if (!redis_hash_get_str(&id, &call, "rtpe_connection_addr"))
+		call_str_cpy(c, &c->rtpe_connection_addr, &id);
 	if (!redis_hash_get_int(&i, &call, "block_dtmf"))
 		c->block_dtmf = i ? 1 : 0;
 	if (!redis_hash_get_int(&i, &call, "block_media"))
@@ -1879,6 +1881,7 @@ char* redis_encode_json(struct call *c) {
 			JSON_SET_SIMPLE("ml_deleted","%ld",(long int) c->ml_deleted);
 			JSON_SET_SIMPLE_CSTR("created_from",c->created_from);
 			JSON_SET_SIMPLE_CSTR("created_from_addr",sockaddr_print_buf(&c->created_from_addr));
+			JSON_SET_SIMPLE_STR("rtpe_connection_addr", &c->rtpe_connection_addr);
 			JSON_SET_SIMPLE("redis_hosted_db","%u",c->redis_hosted_db);
 			JSON_SET_SIMPLE_STR("recording_metadata",&c->metadata);
 			JSON_SET_SIMPLE("block_dtmf","%i",c->block_dtmf ? 1 : 0);

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -1571,7 +1571,7 @@ static int replace_network_address(struct sdp_chopper *chop, struct network_addr
 		struct packet_stream *ps, struct sdp_ng_flags *flags, int keep_unspec)
 {
 	char buf[64];
-	int len;
+	str res = { buf, 0 };
 	struct packet_stream *sink = packet_stream_sink(ps);
 
 	if (is_addr_unspecified(&address->parsed)
@@ -1583,14 +1583,9 @@ static int replace_network_address(struct sdp_chopper *chop, struct network_addr
 
 	if (flags->media_address.s && is_addr_unspecified(&flags->parsed_media_address))
 		__parse_address(&flags->parsed_media_address, NULL, NULL, &flags->media_address);
-
-	if (!is_addr_unspecified(&flags->parsed_media_address))
-		len = sprintf(buf, "%s %s",
-				flags->parsed_media_address.family->rfc_name,
-				sockaddr_print_buf(&flags->parsed_media_address));
-	else
-		call_stream_address46(buf, ps, SAF_NG, &len, NULL, keep_unspec);
-	chopper_append(chop, buf, len);
+	
+	format_network_address(&res, ps, flags, keep_unspec);
+	chopper_append(chop, res.s, res.len);
 
 	if (skip_over(chop, &address->address))
 		return -1;

--- a/include/call.h
+++ b/include/call.h
@@ -383,7 +383,8 @@ struct call {
 	char			*created_from;
 	sockaddr_t		created_from_addr;
 	sockaddr_t		xmlrpc_callback;
-
+	str			rtpe_connection_addr;
+	
 	unsigned int		redis_hosted_db;
 	unsigned int		foreign_call; // created_via_redis_notify call
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -124,5 +124,6 @@ void ng_call_stats(struct call *call, const str *fromtag, const str *totag, benc
 
 int call_interfaces_init(void);
 
+void format_network_address(str* o, struct packet_stream *ps, struct sdp_ng_flags *flags, int keep_unspec);
 
 #endif


### PR DESCRIPTION
The current model for creating RTPEngine clusters, as documented in the [Redis keyspace notification](https://github.com/sipwise/rtpengine/wiki/Redis-keyspace-notifications) wiki page, require a static configuration where the exact topology of the cluster is fully known ahead of time, and a Redis keyspace is allocated for each cluster member.

Here we introduce a new way to handle RTPEngine clusters that allows a cluster to scale out and in automatically without pre-configuring each cluster member with all the known addresses of all other members. This configuration supports a completely stateless message distribution (for example as that offered by a layer 3 network load balancer) by remembering the network identity of a call owner in the Redis-distributed data structure and allowing a node that receives a command for a session created by another node to answer with the owner's network identity without knowing it ahead of time.

This patch, though minimal, is probably a bit too hackish - and is not configurable at all - so it is presented here as a basis for discussion. Please let me know what you think.