### PR TITLE
use pkg-config to detect xtables library for iptables-extension

### DIFF
--- a/iptables-extension/Makefile
+++ b/iptables-extension/Makefile
@@ -11,7 +11,17 @@ else
   endif
 endif
 
-XTABLES		= $(shell test -e /usr/include/xtables.h && echo 1)
+XTABLES_INSTALLED=$(shell \
+  if pkg-config --exists xtables; then \
+    echo 'xtables found'; \
+  fi)
+ifneq ($(XTABLES_INSTALLED),)
+XTABLES = 1
+CFLAGS  += $(shell pkg-config --cflags --libs xtables)
+else
+XTABLES = $(shell test -e /usr/include/xtables.h && echo 1)
+endif
+
 IPTABLES	= $(shell test -e /usr/include/iptables.h && echo 1)
 IP6TABLES	= $(shell test -e /usr/include/ip6tables.h && echo 1)
 


### PR DESCRIPTION
In some OSes (e.g, Suse), the xtables library installs the headers in custom path and the current Makefile fails to find it. The patch doesn't try to detect if `pkg-config` is installed, because it is listed as a build dependency, but can be added if wanted.