### PR TITLE
Fix crash when redis disconnects/reconnects

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -572,7 +572,6 @@ static int redis_notify(void) {
 }
 
 static void redis_disconnect(void) {
-	redisAsyncDisconnect(rtpe_redis_notify_async_context);
 	rtpe_redis_notify_async_context = NULL;
 }
 
@@ -634,6 +633,7 @@ void redis_notify_loop(void *d) {
 	redis_notify_subscribe_action(UNSUBSCRIBE_ALL, 0);
 
 	// free async context
+	redisAsyncDisconnect(rtpe_redis_notify_async_context);
 	redis_disconnect();
 }
 


### PR DESCRIPTION
Steps to reproduce:
1. start rtpengine with redis support
2. stop the redis server
3. start the redis server => wait for rtpengine to reconnect => crash

From [1] I've found out that:
1. "The asynchronous context can hold a disconnect callback function that is called when the connection is disconnected (either because of an error or per user request)"
2. "The context object is always freed after the disconnect callback fired."

So I think there is no point in calling redisAsyncDisconnect() on redis reconnect; this will lead to the crash.

[1] https://github.com/redis/hiredis