### PR TITLE
Jitter buffer Changes

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2261,7 +2261,7 @@ no_stats_output:
 		ps = l->data;
 
 		send_timer_put(&ps->send_timer);
-		obj_put(&ps->jb->ttq.tt_obj);
+                jb_put(&ps->jb);
 		__unkernelize(ps);
 		dtls_shutdown(ps);
 		ps->selected_sfd = NULL;

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2261,7 +2261,7 @@ no_stats_output:
 		ps = l->data;
 
 		send_timer_put(&ps->send_timer);
-                jb_put(&ps->jb);
+		jb_put(&ps->jb);
 		__unkernelize(ps);
 		dtls_shutdown(ps);
 		ps->selected_sfd = NULL;

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2261,7 +2261,7 @@ no_stats_output:
 		ps = l->data;
 
 		send_timer_put(&ps->send_timer);
-		jitter_buffer_free(&ps->jb);
+		obj_put(&ps->jb->ttq.tt_obj);
 		__unkernelize(ps);
 		dtls_shutdown(ps);
 		ps->selected_sfd = NULL;

--- a/daemon/jitter_buffer.c
+++ b/daemon/jitter_buffer.c
@@ -258,8 +258,8 @@ static void decrement_buffer(struct jitter_buffer *jb) {
 
 static void set_jitter_values(struct media_packet *mp) {
 	struct jitter_buffer *jb = mp->stream->jb;
-        if(!jb || !mp->rtp)
-                return;
+	if(!jb || !mp->rtp)
+		return;
 	int curr_seq = ntohs(mp->rtp->seq_num); 
 	if(jb->next_exp_seq) {
 		mutex_lock(&jb->lock);

--- a/daemon/jitter_buffer.c
+++ b/daemon/jitter_buffer.c
@@ -257,7 +257,6 @@ static void decrement_buffer(struct jitter_buffer *jb) {
 }
 
 static void set_jitter_values(struct media_packet *mp) {
-	int ret=0;
 	struct jitter_buffer *jb = mp->stream->jb;
         if(!jb || !mp->rtp)
                 return;

--- a/daemon/timerthread.c
+++ b/daemon/timerthread.c
@@ -92,8 +92,10 @@ nope:
 static int timerthread_queue_run_one(struct timerthread_queue *ttq,
 		struct timerthread_queue_entry *ttqe,
 		void (*run_func)(struct timerthread_queue *, void *)) {
-	if (ttqe->when.tv_sec && timeval_cmp(&ttqe->when, &rtpe_now) > 0)
-		return -1; // not yet
+	if (ttqe->when.tv_sec && timeval_cmp(&ttqe->when, &rtpe_now) > 0) {
+		if(timeval_diff(&ttqe->when, &rtpe_now) > 1000) // not to queue packet less than 1ms
+			return -1; // not yet
+	}
 	run_func(ttq, ttqe);
 	return 0;
 }

--- a/include/jitter_buffer.h
+++ b/include/jitter_buffer.h
@@ -15,7 +15,6 @@ struct jb_packet {
 	struct timerthread_queue_entry ttq_entry;
 	char *buf;
 	struct media_packet mp;
-	//int buffered;
 };
 
 struct jitter_buffer {
@@ -32,12 +31,10 @@ struct jitter_buffer {
 	unsigned int            payload_type;
 	unsigned int            num_resets;
 	unsigned int            initial_pkts;
-	unsigned int            cont_buff_err;
+	unsigned int            drift_mult_factor;
 	int            		buffer_len;
 	int                     clock_drift_val;
-	int                     clock_drift_enable; //flag for buffer overflow underflow
 	int                     buf_decremented;
-	struct jb_packet 	*p;
 	struct call             *call;
 	int			disabled;
 };
@@ -49,8 +46,6 @@ void jitter_buffer_free(struct jitter_buffer **);
 
 int buffer_packet(struct media_packet *mp, const str *s);
 void jb_packet_free(struct jb_packet **jbp);
-
-//int set_jitter_values(struct media_packet *mp);
 
 void jitter_buffer_loop(void *p);
 

--- a/include/jitter_buffer.h
+++ b/include/jitter_buffer.h
@@ -49,4 +49,11 @@ void jb_packet_free(struct jb_packet **jbp);
 
 void jitter_buffer_loop(void *p);
 
+INLINE void jb_put(struct jitter_buffer **jb) {
+        if (!*jb)
+                return;
+        obj_put(&(*jb)->ttq.tt_obj);
+        *jb = NULL;
+}
+
 #endif

--- a/include/jitter_buffer.h
+++ b/include/jitter_buffer.h
@@ -50,10 +50,10 @@ void jb_packet_free(struct jb_packet **jbp);
 void jitter_buffer_loop(void *p);
 
 INLINE void jb_put(struct jitter_buffer **jb) {
-        if (!*jb)
-                return;
-        obj_put(&(*jb)->ttq.tt_obj);
-        *jb = NULL;
+	if (!*jb)
+		return;
+	obj_put(&(*jb)->ttq.tt_obj);
+	*jb = NULL;
 }
 
 #endif


### PR DESCRIPTION
The following changes are made in this PR.
1. Jitter_buffer free through timerthread_obj
2. jitter_buffer.c:91 - Corrected wrong str object passed to rtp_payload
3. Clock drift handling made simpler, Now for every 20, 40, 80, 160, 320 ... packets clock drift corrected if enabled in config 
4. Removed buffering first packet. The first packet Immediately sent without buffering.