### PR TITLE
kernel-module: fix implicit function declaration

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -2,6 +2,7 @@
 #include <linux/module.h>
 #include <linux/skbuff.h>
 #include <linux/ip.h>
+#include <net/ip6_checksum.h>
 #include <linux/udp.h>
 #include <linux/icmp.h>
 #include <linux/version.h>


### PR DESCRIPTION
Hi all,

We added rtpengine to OpenWrt [here](https://github.com/openwrt/telephony/tree/master/net/rtpengine), after users requested it on the forum.

We don't really have many patches for rtpengine. The ones we do have are mostly not relevant for rtpengine upstream. But maybe this missing header patch is?

Kind regards,
Seb

This commit adds a header to the mix to prevent the following compile
error:

make[3]: Entering directory '/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/rtpengine-no-transcode/rtpengine-mr8.3.1.4/kernel-module'
make -C /home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/linux-4.19.122 M=/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/rtpengine-no-transcode/rtpengine-mr8.3.1.4/kernel-module O=/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/linux-4.19.122 modules
make[4]: Entering directory '/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/linux-4.19.122'
make[5]: Entering directory '/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/linux-4.19.122'
  CC [M]  /home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/rtpengine-no-transcode/rtpengine-mr8.3.1.4/kernel-module/xt_RTPENGINE.o
/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/rtpengine-no-transcode/rtpengine-mr8.3.1.4/kernel-module/xt_RTPENGINE.c: In function 'send_proxy_packet6':
/home/sk/tmp/openwrt/build_dir/target-mips_24kc_musl/linux-ath79_generic/rtpengine-no-transcode/rtpengine-mr8.3.1.4/kernel-module/xt_RTPENGINE.c:3387:14: error: implicit declaration of function 'csum_ipv6_magic'; did you mean 'csum_tcpudp_magic'? [-Werror=implicit-function-declaration]
  uh->check = csum_ipv6_magic(&ih->saddr, &ih->daddr, datalen, IPPROTO_UDP, csum_partial(uh, datalen, 0));
              ^~~~~~~~~~~~~~~
              csum_tcpudp_magic
cc1: some warnings being treated as errors

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>