### PR TITLE
Add drop-traffic start and stop flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,18 @@ Optionally included keys are:
 	Used if SDP addresses are neither trusted (through `SIP source address` or `--sip-source`) nor the
 	`media address` key is present.
 
+* `drop-traffic`
+
+	Contains a string, valid values are `start` or `stop`.
+
+	`start` signals to *rtpengine* that all RTP involved in this call is dropped.
+	Can be present either in `offer` or `answer`, the behavior is for the entire call.
+
+	`stop` signals to *rtpengine* that all RTP involved in this call is NOT dropped anymore.
+	Can be present either in `offer` or `answer`, the behavior is for the entire call.
+
+	`stop` has priority over `start`, if both are present.
+
 * `ICE`
 
 	Contains a string, valid values are `remove`, `force` or `force-relay`.

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -887,6 +887,20 @@ static void call_ng_process_flags(struct sdp_ng_flags *out, bencode_item_t *inpu
 		bencode_get_str(it->sibling, &out->received_from_address);
 	}
 
+	if (bencode_dictionary_get_str(input, "drop-traffic", &s)) {
+		switch (__csh_lookup(&s)) {
+			case CSH_LOOKUP("start"):
+				out->drop_traffic_start = 1;
+				break;
+			case CSH_LOOKUP("stop"):
+				out->drop_traffic_stop = 1;
+				break;
+			default:
+				ilog(LOG_WARN, "Unknown 'drop-traffic' flag encountered: '"STR_FORMAT"'",
+						STR_FMT(&s));
+		}
+	}
+
 	if (bencode_dictionary_get_str(input, "ICE", &s)) {
 		switch (__csh_lookup(&s)) {
 			case CSH_LOOKUP("remove"):
@@ -1144,6 +1158,14 @@ static const char *call_offer_answer_ng(bencode_item_t *input,
 	if (flags.record_call) {
 		call->recording_on = 1;
 		recording_start(call, NULL, &flags.metadata);
+	}
+
+	if (flags.drop_traffic_start) {
+		call->drop_traffic = 1;
+	}
+
+	if (flags.drop_traffic_stop) {
+		call->drop_traffic = 0;
 	}
 
 	ret = monologue_offer_answer(monologue, &streams, &flags);

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -1825,6 +1825,9 @@ static int stream_packet(struct packet_handler_ctx *phc) {
 	if (!phc->mp.stream->selected_sfd)
 		goto out;
 
+	if (phc->mp.call && phc->mp.call->drop_traffic) {
+		goto drop;
+	}
 
 	int stun_ret = media_demux_protocols(phc);
 	if (stun_ret == 0) // packet processed

--- a/include/call.h
+++ b/include/call.h
@@ -406,6 +406,7 @@ struct call {
 	int			block_media:1;
 	int			recording_on:1;
 	int			rec_forwarding:1;
+	int			drop_traffic:1;
 };
 
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -99,7 +99,9 @@ struct sdp_ng_flags {
 	    sdes_encrypted_srtcp:1,
 	    sdes_authenticated_srtp:1,
 	    sdes_lifetime:1,
-	    sdes_pad:1;
+	    sdes_pad:1,
+	    drop_traffic_start:1,
+	    drop_traffic_stop:1;
 };
 
 


### PR DESCRIPTION
Useful when someone needs to:
  - completely drop early media, but stop dropping after call is answered.
  - completely drop initial invite media, but stop dropping after re-invite

Tested by toggling re-INVITES and checking that audio was or was not heard.