### PR TITLE
Solve Vlagrind "definitely lost" memory leaks

### DIFF
--- a/daemon/aux.c
+++ b/daemon/aux.c
@@ -141,8 +141,10 @@ void threads_join_all(int wait) {
 			pthread_join(*t, NULL);
 			threads_to_join = g_list_delete_link(threads_to_join, threads_to_join);
 			l = g_list_find_custom(threads_running, t, thread_equal);
-			if (l)
+			if (l) {
+				g_slice_free1(sizeof(*t), l->data);
 				threads_running = g_list_delete_link(threads_running, l);
+			}
 			else
 				abort();
 			g_slice_free1(sizeof(*t), t);
@@ -263,4 +265,12 @@ int g_tree_find_all_cmp(void *k, void *v, void *d) {
 void free_buf(char **p) {
 	if (*p)
 		free(*p);
+}
+
+void free_gbuf(char **p) {
+	g_free(*p);
+}
+
+void free_gvbuf(char ***p) {
+	g_strfreev(*p);
 }

--- a/include/aux.h
+++ b/include/aux.h
@@ -232,6 +232,8 @@ INLINE int rlim(int res, rlim_t val) {
 }
 
 void free_buf(char **);
+void free_gbuf(char **);
+void free_gvbuf(char ***);
 
 
 

--- a/lib/auxlib.h
+++ b/lib/auxlib.h
@@ -42,6 +42,7 @@ extern volatile int rtpe_shutdown;
 void daemonize(void);
 void wpidfile(void);
 void service_notify(const char *message);
+void config_load_free(struct rtpengine_common_config *);
 void config_load(int *argc, char ***argv, GOptionEntry *entries, const char *description,
 		char *default_config, char *default_section,
 		struct rtpengine_common_config *);
@@ -64,6 +65,8 @@ int uint32_eq(const void *a, const void *b);
 #define AUTO_CLEANUP_INIT(decl, func, val)	AUTO_CLEANUP(decl, func) = val
 #define AUTO_CLEANUP_NULL(decl, func)		AUTO_CLEANUP_INIT(decl, func, 0)
 #define AUTO_CLEANUP_BUF(var)			AUTO_CLEANUP_NULL(char *var, free_buf)
+#define AUTO_CLEANUP_GBUF(var)			AUTO_CLEANUP_NULL(char *var, free_gbuf)
+#define AUTO_CLEANUP_GVBUF(var)			AUTO_CLEANUP_NULL(char **var, free_gvbuf)
 
 
 /*** STRING HELPERS ***/

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -15,18 +15,18 @@ enum output_storage_enum {
 extern int ktable;
 extern int num_threads;
 extern enum output_storage_enum output_storage;
-extern const char *spool_dir;
-extern const char *output_dir;
+extern char *spool_dir;
+extern char *output_dir;
 extern int output_mixed;
 extern int output_single;
 extern int output_enabled;
 extern int decoding_enabled;
-extern const char *c_mysql_host,
+extern char *c_mysql_host,
       *c_mysql_user,
       *c_mysql_pass,
       *c_mysql_db;
 extern int c_mysql_port;
-extern const char *forward_to;
+extern char *forward_to;
 extern endpoint_t tls_send_to_ep;
 extern int tls_resample;
 


### PR DESCRIPTION
1. run rtpengine under valgrind: sudo valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose --log-file=valgrind-out1.txt daemon/rtpengine -f -E --no-log-timestamps --pidfile /run/ngcp-rtpengine-daemon.pid --config-file /etc/rtpengine/rtpengine1.conf
2. wait it to start
3. Ctrl+c

Vlagrind reports lots of memory warnings. Some of them are "definitely lost" (attached file) which are definitely memory leaks.

After this commit, there are 0 "definitely lost" warnings that valgrind reports(for the above steps).

[valgrind_definitely.txt](https://github.com/sipwise/rtpengine/files/4750748/valgrind_definitely.txt)
