### PR TITLE
Solve Valgrind "possibly lost" for redis and dtls

### DIFF
--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -384,6 +384,19 @@ struct dtls_cert *dtls_cert() {
 	return ret;
 }
 
+void dtls_cert_free(void) {
+	rwlock_lock_w(&__dtls_cert_lock);
+
+	if (__dtls_cert)
+		obj_put(__dtls_cert);
+
+	__dtls_cert = NULL;
+
+	rwlock_unlock_w(&__dtls_cert_lock);
+
+	return ;
+}
+
 static int verify_callback(int ok, X509_STORE_CTX *store) {
 	SSL *ssl;
 	struct dtls_connection *d;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -942,6 +942,11 @@ int main(int argc, char **argv) {
 
 	ilog(LOG_INFO, "Version %s shutting down", RTPENGINE_VERSION);
 
+	redis_close(rtpe_redis);
+	redis_close(rtpe_redis_write);
+	redis_close(rtpe_redis_notify);
+	dtls_cert_free();
+
 	unfill_initial_rtpe_cfg(&initial_rtpe_config);
 
 	options_free();

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -631,6 +631,9 @@ void redis_notify_loop(void *d) {
 		}
 	}
 
+	// free libevent
+	libevent_global_shutdown();
+
 	// unsubscribe notifications
 	redis_notify_subscribe_action(UNSUBSCRIBE_ALL, 0);
 
@@ -677,7 +680,9 @@ err:
 }
 
 
-static void redis_close(struct redis *r) {
+void redis_close(struct redis *r) {
+	if (!r)
+		return;
 	if (r->ctx)
 		redisFree(r->ctx);
 	r->ctx = NULL;

--- a/include/dtls.h
+++ b/include/dtls.h
@@ -66,6 +66,7 @@ void dtls_timer(struct poller *);
 int dtls_verify_cert(struct packet_stream *ps);
 const struct dtls_hash_func *dtls_find_hash_func(const str *);
 struct dtls_cert *dtls_cert(void);
+void dtls_cert_free(void);
 
 int dtls_connection_init(struct dtls_connection *, struct packet_stream *, int active, struct dtls_cert *cert);
 int dtls(struct stream_fd *, const str *s, const endpoint_t *sin);

--- a/include/redis.h
+++ b/include/redis.h
@@ -102,6 +102,7 @@ void redis_notify_loop(void *d);
 
 
 struct redis *redis_new(const endpoint_t *, int, const char *, enum redis_role, int);
+void redis_close(struct redis *r);
 int redis_restore(struct redis *);
 void redis_update(struct call *, struct redis *);
 void redis_update_onekey(struct call *c, struct redis *r);


### PR DESCRIPTION
There is 1 more warning related to this, that I am confused how to solve:
```
==30466== 64 bytes in 1 blocks are still reachable in loss record 211 of 387
==30466==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==30466==    by 0x522BAB8: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.4)
==30466==    by 0x51F95A2: g_async_queue_new_full (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.4)
==30466==    by 0x524EA0C: g_thread_pool_new (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5600.4)
==30466==    by 0x12DD6F: redis_restore (redis.c:1758)
==30466==    by 0x119D82: create_everything (main.c:868)
==30466==    by 0x119D82: main (main.c:892)
```          
I think it might be related to the glibc since ```g_thread_pool_free``` should already do all the job.

I tried creating a small test program only with ```g_thread_pool_new``` ```g_thread_pool_free``` with empty thread  callback and valgrind still reported the above warning.