### PR TITLE
Few more valgrind fixes

### DIFF
--- a/daemon/tcp_listener.c
+++ b/daemon/tcp_listener.c
@@ -247,7 +247,8 @@ void streambuf_listener_shutdown(struct streambuf_listener *listener) {
 		return;
 	poller_del_item(listener->poller, listener->listener.fd);
 	close_socket(&listener->listener);
-	g_hash_table_destroy(listener->streams);
+	if (listener->streams)
+		g_hash_table_destroy(listener->streams);
 }
 
 void streambuf_stream_close(struct streambuf_stream *s) {

--- a/lib/auxlib.c
+++ b/lib/auxlib.c
@@ -102,16 +102,20 @@ void config_load_free(struct rtpengine_common_config *cconfig) {
 }
 
 static void free_gkeyfile(GKeyFile **k) {
-	g_key_file_free(*k);
+	if (k && *k)
+		g_key_file_free(*k);
 }
 static void free_gopte(GOptionEntry **k) {
-	free(*k);
+	if (k && *k)
+		free(*k);
 }
 static void free_goptc(GOptionContext **k) {
-	g_option_context_free(*k);
+	if (k && *k)
+		g_option_context_free(*k);
 }
 static void free_gerror(GError **k) {
-	g_error_free(*k);
+	if (k && *k)
+		g_error_free(*k);
 }
 
 void config_load(int *argc, char ***argv, GOptionEntry *app_entries, const char *description,

--- a/lib/str.h
+++ b/lib/str.h
@@ -62,6 +62,7 @@ INLINE str *str_init_len_assert_len(str *out, char *s, int buflen, int len);
 #define str_init_len_assert(out, s, len) str_init_len_assert_len(out, s, sizeof(s), len)
 /* inits a str object from a regular string and duplicates the contents. returns out */
 INLINE str *str_init_dup(str *out, char *s);
+INLINE void str_free_dup(str *out);
 /* returns new str object with uninitialized buffer large enough to hold `len` characters (+1 for null byte) */
 INLINE str *str_alloc(int len);
 /* returns new str object allocated with malloc, including buffer */
@@ -234,6 +235,16 @@ INLINE str *str_init_dup(str *out, char *s) {
 	out->s = s ? strdup(s) : NULL;
 	out->len = s ? strlen(s) : 0;
 	return out;
+}
+INLINE void str_free_dup(str *out) {
+	if (!out)
+		return ;
+
+	if (out->s)
+		free(out->s);
+
+	out->s = NULL;
+	out->len = 0;
 }
 INLINE str *str_alloc(int len) {
 	str *r;


### PR DESCRIPTION
- free the allocate str_init_dup() for if name
- clear the queues for keyspaces and interfaces config