### PR TITLE
Fix Valgrind "still reachable" for a few others

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -2102,6 +2102,27 @@ out:
 #endif
 }
 
+void call_interfaces_free() {
+	if (info_re) {
+		pcre_free(info_re);
+		info_re = NULL;
+	}
+
+	if (streams_re) {
+		pcre_free(streams_re);
+		streams_re= NULL;
+	}
+
+	if (info_ree) {
+		pcre_free_study(info_ree);
+		info_ree = NULL;
+	}
+
+	if (streams_ree) {
+		pcre_free_study(streams_ree);
+		streams_ree = NULL;
+	}
+}
 
 int call_interfaces_init() {
 	const char *errptr;

--- a/daemon/ice.c
+++ b/daemon/ice.c
@@ -554,6 +554,10 @@ void ice_init(void) {
 	timerthread_init(&ice_agents_timer_thread, ice_agents_timer_run);
 }
 
+void ice_free(void) {
+	timerthread_free(&ice_agents_timer_thread);
+}
+
 
 
 static void __fail_pair(struct ice_candidate_pair *pair) {

--- a/daemon/jitter_buffer.c
+++ b/daemon/jitter_buffer.c
@@ -23,6 +23,11 @@ void jitter_buffer_init(void) {
 	timerthread_init(&jitter_buffer_thread, timerthread_queue_run);
 }
 
+void jitter_buffer_init_free(void) {
+	ilog(LOG_DEBUG, "jitter_buffer_free");
+	timerthread_free(&jitter_buffer_thread);
+}
+
 static void jitter_buffer_flush(struct jitter_buffer *jb) {
 	mutex_unlock(&jb->lock);
 	timerthread_queue_flush_data(&jb->ttq);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -960,16 +960,26 @@ int main(int argc, char **argv) {
 
 	ilog(LOG_INFO, "Version %s shutting down", RTPENGINE_VERSION);
 
+	unfill_initial_rtpe_cfg(&initial_rtpe_config);
+
+	call_free();
+
+	jitter_buffer_init_free();
+	media_player_free();
+	codeclib_free();
+	statistics_free();
+	call_interfaces_free();
+	interfaces_free();
+	ice_free();
+	dtls_cert_free();
+
 	redis_close(rtpe_redis);
 	redis_close(rtpe_redis_write);
 	redis_close(rtpe_redis_notify);
-	dtls_cert_free();
-
-	unfill_initial_rtpe_cfg(&initial_rtpe_config);
 
 	options_free();
-	call_free();
-	interfaces_free();
+
+	log_free();
 
 	obj_release(rtpe_cli);
 	obj_release(rtpe_udp);

--- a/daemon/media_player.c
+++ b/daemon/media_player.c
@@ -753,6 +753,13 @@ void media_player_init(void) {
 	timerthread_init(&send_timer_thread, timerthread_queue_run);
 }
 
+void media_player_free(void) {
+#ifdef WITH_TRANSCODING
+	timerthread_free(&media_player_thread);
+#endif
+	timerthread_free(&send_timer_thread);
+}
+
 
 #ifdef WITH_TRANSCODING
 void media_player_loop(void *p) {

--- a/daemon/statistics.c
+++ b/daemon/statistics.c
@@ -630,6 +630,26 @@ void statistics_free_metrics(GQueue **q) {
 	*q = NULL;
 }
 
+void statistics_free() {
+	mutex_destroy(&rtpe_totalstats.total_average_lock);
+	mutex_destroy(&rtpe_totalstats_interval.total_average_lock);
+	mutex_destroy(&rtpe_totalstats_interval.managed_sess_lock);
+	mutex_destroy(&rtpe_totalstats_interval.total_calls_duration_lock);
+
+	mutex_destroy(&rtpe_totalstats_lastinterval_lock);
+
+	mutex_destroy(&rtpe_totalstats_interval.offer.lock);
+	mutex_destroy(&rtpe_totalstats_interval.answer.lock);
+	mutex_destroy(&rtpe_totalstats_interval.delete.lock);
+
+	mutex_destroy(&rtpe_totalstats_interval.offers_ps.lock);
+	mutex_destroy(&rtpe_totalstats_interval.answers_ps.lock);
+	mutex_destroy(&rtpe_totalstats_interval.deletes_ps.lock);
+
+	mutex_destroy(&rtpe_codec_stats_lock);
+	g_hash_table_destroy(rtpe_codec_stats);
+}
+
 void statistics_init() {
 	mutex_init(&rtpe_totalstats.total_average_lock);
 	mutex_init(&rtpe_totalstats_interval.total_average_lock);

--- a/daemon/timerthread.c
+++ b/daemon/timerthread.c
@@ -14,6 +14,11 @@ void timerthread_init(struct timerthread *tt, void (*func)(void *)) {
 	tt->func = func;
 }
 
+void timerthread_free(struct timerthread *tt) {
+	g_tree_destroy(tt->tree);
+	mutex_destroy(&tt->lock);
+}
+
 void timerthread_run(void *p) {
 	struct timerthread *tt = p;
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -139,6 +139,7 @@ void ng_call_stats(struct call *call, const str *fromtag, const str *totag, benc
 		struct call_stats *totals);
 
 int call_interfaces_init(void);
+void call_interfaces_free(void);
 
 
 #endif

--- a/include/ice.h
+++ b/include/ice.h
@@ -141,6 +141,7 @@ extern const char * const ice_type_strings[];
 
 
 void ice_init(void);
+void ice_free(void);
 
 enum ice_candidate_type ice_candidate_type(const str *s);
 int ice_has_related(enum ice_candidate_type);

--- a/include/jitter_buffer.h
+++ b/include/jitter_buffer.h
@@ -42,6 +42,7 @@ struct jitter_buffer {
 };
 
 void jitter_buffer_init(void);
+void jitter_buffer_init_free(void);
 
 struct jitter_buffer *jitter_buffer_new(struct call *);
 void jitter_buffer_free(struct jitter_buffer **);

--- a/include/media_player.h
+++ b/include/media_player.h
@@ -87,6 +87,7 @@ void media_player_add_packet(struct media_player *mp, char *buf, size_t len,
 		long long us_dur, unsigned long long pts);
 
 void media_player_init(void);
+void media_player_free(void);
 void media_player_loop(void *);
 
 struct send_timer *send_timer_new(struct packet_stream *);

--- a/include/statistics.h
+++ b/include/statistics.h
@@ -130,5 +130,6 @@ void statistics_free_metrics(GQueue **);
 const char *statistics_ng(bencode_item_t *input, bencode_item_t *output);
 
 void statistics_init(void);
+void statistics_free(void);
 
 #endif /* STATISTICS_H_ */

--- a/include/timerthread.h
+++ b/include/timerthread.h
@@ -41,6 +41,7 @@ struct timerthread_queue_entry {
 
 
 void timerthread_init(struct timerthread *, void (*)(void *));
+void timerthread_free(struct timerthread *);
 void timerthread_run(void *);
 
 void timerthread_obj_schedule_abs_nl(struct timerthread_obj *, const struct timeval *);

--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -759,6 +759,12 @@ static void avc_def_init(codec_def_t *def) {
 	}
 }
 
+void codeclib_free(void) {
+	g_hash_table_destroy(codecs_ht);
+	g_hash_table_destroy(codecs_ht_by_av);
+	avformat_network_deinit();
+}
+
 void codeclib_init(int print) {
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	av_register_all();

--- a/lib/codeclib.h
+++ b/lib/codeclib.h
@@ -211,6 +211,7 @@ struct packet_sequencer_s {
 
 
 void codeclib_init(int);
+void codeclib_free(void);
 
 
 const codec_def_t *codec_find(const str *name, enum media_type);

--- a/lib/loglib.c
+++ b/lib/loglib.c
@@ -230,6 +230,12 @@ void log_init(const char *handle) {
 		openlog(handle, LOG_PID | LOG_NDELAY, ilog_facility);
 }
 
+void log_free() {
+	g_hash_table_destroy(__log_limiter);
+	g_string_chunk_free(__log_limiter_strings);
+	pthread_mutex_destroy(&__log_limiter_lock);
+}
+
 int parse_log_facility(const char *name, int *dst) {
 	int i;
 	for (i = 0 ; _facilitynames[i].c_name; i++) {

--- a/lib/loglib.h
+++ b/lib/loglib.h
@@ -23,6 +23,7 @@ void print_available_log_facilities (void);
 void log_to_stderr(int facility_priority, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
 
 void log_init(const char *);
+void log_free(void);
 
 void __vpilog(int prio, const char *prefix, const char *fmt, va_list);
 void __ilog_np(int prio, const char *format, ...) __attribute__ ((format (printf, 2, 3)));


### PR DESCRIPTION
log, ice, media_player, jitter_buffer, statistics, codeclib, call_interfaces

After this commit, and using the glib suppression file [1] just two other valgrind warnings show up upon start-stop rtpengine:

1. av lib related (even if i call the avformat_network_deinit()):
```
==14340== 40 bytes in 1 blocks are still reachable in loss record 137 of 264
==14340==    at 0x4C32443: memalign (vg_replace_malloc.c:906)
==14340==    by 0x4C32546: posix_memalign (vg_replace_malloc.c:1070)
==14340==    by 0x93F0662: av_malloc (in /usr/lib/x86_64-linux-gnu/libavutil.so.55.78.100)
==14340==    by 0x7ED0099: ??? (in /usr/lib/x86_64-linux-gnu/libavcodec.so.57.107.100)
==14340==    by 0x7ED40FD: avpriv_lock_avformat (in /usr/lib/x86_64-linux-gnu/libavcodec.so.57.107.100)
==14340==    by 0x9100008: ??? (in /usr/lib/x86_64-linux-gnu/libavformat.so.57.83.100)
==14340==    by 0x9097248: ??? (in /usr/lib/x86_64-linux-gnu/libavformat.so.57.83.100)
==14340==    by 0x911398E: avformat_network_init (in /usr/lib/x86_64-linux-gnu/libavformat.so.57.83.100)
==14340==    by 0x17903A: codeclib_init (codeclib.c:775)
==14340==    by 0x119CCB: init_everything (main.c:761)
==14340==    by 0x119CCB: main (main.c:902)
``` 

2. glib related:
```
==14340== 96 bytes in 1 blocks are still reachable in loss record 184 of 264
==14340==    at 0x4C2FECB: malloc (vg_replace_malloc.c:307)
==14340==    by 0x5230D08: g_malloc (gmem.c:106)
==14340==    by 0x52498D5: g_slice_alloc (gslice.c:1025)
==14340==    by 0x5218A9D: g_hash_table_new_full (ghash.c:1071)
==14340==    by 0x523B96A: g_quark_init (gquark.c:61)
==14340==    by 0x4010732: call_init (dl-init.c:72)
==14340==    by 0x4010732: _dl_init (dl-init.c:119)
==14340==    by 0x40010C9: ??? (in /lib/x86_64-linux-gnu/ld-2.27.so)
==14340==    by 0x7: ???
==14340==    by 0x1FFF000572: ???
==14340==    by 0x1FFF000583: ???
==14340==    by 0x1FFF000586: ???
==14340==    by 0x1FFF000589: ???


==14340== 16,384 bytes in 1 blocks are still reachable in loss record 264 of 264
==14340==    at 0x4C2FECB: malloc (vg_replace_malloc.c:307)
==14340==    by 0x5230D08: g_malloc (gmem.c:106)
==14340==    by 0x523B97B: g_quark_init (gquark.c:62)
==14340==    by 0x4010732: call_init (dl-init.c:72)
==14340==    by 0x4010732: _dl_init (dl-init.c:119)
==14340==    by 0x40010C9: ??? (in /lib/x86_64-linux-gnu/ld-2.27.so)
==14340==    by 0x7: ???
==14340==    by 0x1FFF000572: ???
==14340==    by 0x1FFF000583: ???
==14340==    by 0x1FFF000586: ???
==14340==    by 0x1FFF000589: ???
==14340==    by 0x1FFF00059D: ???
==14340==    by 0x1FFF0005A7: ???
```

However, there are no warnings strictly related to rtpengine code, for the basic start-stop scenario :smiley:

[1] https://github.com/GNOME/glib/blob/mainline/glib.supp