### PR TITLE
Added message compression/uncompression

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -127,7 +127,7 @@ SRCS=		main.c kernel.c poller.c aux.c control_tcp.c call.c control_udp.c redis.c
 		bencode.c cookie_cache.c udp_listener.c control_ng.strhash.c sdp.strhash.c stun.c rtcp.c \
 		crypto.c rtp.c call_interfaces.strhash.c dtls.c log.c cli.c graphite.c ice.c \
 		media_socket.c homer.c recording.c statistics.c cdr.c ssrc.c iptables.c tcp_listener.c \
-		codec.c load.c dtmf.c timerthread.c media_player.c jitter_buffer.c t38.c
+		codec.c load.c dtmf.c timerthread.c media_player.c jitter_buffer.c t38.c compress.c
 LIBSRCS=	loglib.c auxlib.c rtplib.c str.c socket.c streambuf.c ssllib.c dtmflib.c
 ifeq ($(with_transcoding),yes)
 LIBSRCS+=	codeclib.c resample.c

--- a/daemon/compress.c
+++ b/daemon/compress.c
@@ -1,0 +1,75 @@
+
+#include <str.h>
+#include <zlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "log.h"
+#include "udp_listener.h"
+#include "str.h"
+#include "compress.h"
+
+#define windowBits 15
+
+#define GZIP_ENCODING 16
+#define ENABLE_ZLIB_GZIP 32
+
+static void init_stream(z_stream *stream);
+
+static void init_stream(z_stream *stream)
+{
+	stream->zalloc = Z_NULL;
+	stream->zfree = Z_NULL;
+	stream->opaque = Z_NULL;
+}
+
+
+// compress_data compress the data of the given length.
+// returns compressed buffer length and replace the original buffer.
+int compress_data(char *buf, int len) {
+	uLong comp_len = compressBound(len);
+    char tmp[comp_len];
+    int ret;
+
+    ret = compress2((Bytef *)tmp, &comp_len, (Bytef *)buf, len, Z_BEST_COMPRESSION);
+    if (ret != Z_OK) {
+        return -1;
+    }
+
+    memcpy(buf, tmp, comp_len);
+    return comp_len;
+}
+
+// uncompress_data uncompress the compressed data with given length.
+// it compare the first byte to check the compressed data or not.
+int uncompress_data(char *buf, int len, char *buf_tmp, int buf_size) {
+    z_stream stream;
+    int ret;
+
+    init_stream(&stream);
+    ret = inflateInit2(&stream, windowBits | ENABLE_ZLIB_GZIP);
+    if (ret != Z_OK) {
+    	ilog(LOG_ERROR,"Could not initiate zstream.\n");
+        return -1;
+    }
+
+    stream.next_in = (Bytef *)buf;
+    stream.avail_in = len;
+
+	memset(buf_tmp, 0x00, sizeof(buf_tmp));
+	stream.next_out = (Bytef *)buf_tmp;
+	stream.avail_out = buf_size - 1;
+
+	ret = inflate(&stream, Z_NO_FLUSH);
+	if (ret != Z_OK && ret != Z_STREAM_END) {
+		inflateEnd(&stream);
+		ilog(LOG_ERROR,"Could not uncompress the data correctly.\n");
+		return -1;
+	}
+
+	memcpy(buf, buf_tmp, buf_size);
+	ret = stream.total_out;
+	inflateEnd(&stream);
+
+	return ret;
+}

--- a/include/compress.h
+++ b/include/compress.h
@@ -1,0 +1,25 @@
+#ifndef __CODEC_H__
+#define __CODEC_H__
+
+// returns 1 if the given buffer is compressed buffer.
+// Level | ZLIB  | GZIP
+//   1   | 78 01 | 1F 8B
+//   2   | 78 5E | 1F 8B
+//   3   | 78 5E | 1F 8B
+//   4   | 78 5E | 1F 8B
+//   5   | 78 5E | 1F 8B
+//   6   | 78 9C | 1F 8B
+//   7   | 78 DA | 1F 8B
+//   8   | 78 DA | 1F 8B
+//   9   | 78 DA | 1F 8B
+INLINE int is_compressed(char* buf) {
+    if (buf && ((buf[0] == 0x78) || (buf[0] == 0x1F))) {
+        return 1;
+    }
+    return 0;
+}
+
+int uncompress_data(char *buf, int len, char *buf_tmp, int buf_size);
+int compress_data(char *buf, int len);
+
+#endif


### PR DESCRIPTION
Currently, the RTPEngine sends the UDP message without any. compression.

This is fine for most of the cases, but with the complex SDP, the RTPEngine generated over 3000 characters of RTP stats at the end of the call.

Added option for compression the message if the message size is over a certain size.