### PR TITLE
Add redis async delete

### DIFF
--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -995,7 +995,7 @@ static void cli_incoming_ksadd(str *instr, struct streambuf *replybuffer) {
 		rwlock_lock_w(&rtpe_config.config_lock);
 		if (!g_queue_find(&rtpe_config.redis_subscribed_keyspaces, GUINT_TO_POINTER(uint_keyspace_db))) {
 			g_queue_push_tail(&rtpe_config.redis_subscribed_keyspaces, GUINT_TO_POINTER(uint_keyspace_db));
-			redis_notify_subscribe_action(SUBSCRIBE_KEYSPACE, uint_keyspace_db);
+			redis_notify_subscribe_action(rtpe_redis_notify, SUBSCRIBE_KEYSPACE, uint_keyspace_db);
 			streambuf_printf(replybuffer, "Success adding keyspace %lu to redis notifications.\n", uint_keyspace_db);
 		} else {
 			streambuf_printf(replybuffer, "Keyspace %lu is already among redis notifications.\n", uint_keyspace_db);
@@ -1024,7 +1024,7 @@ static void cli_incoming_ksrm(str *instr, struct streambuf *replybuffer) {
                 streambuf_printf(replybuffer, "Fail removing keyspace %s to redis notifications; no digists found\n", instr->s);
 	} else if ((l = g_queue_find(&rtpe_config.redis_subscribed_keyspaces, GUINT_TO_POINTER(uint_keyspace_db)))) {
 		// remove this keyspace
-		redis_notify_subscribe_action(UNSUBSCRIBE_KEYSPACE, uint_keyspace_db);
+		redis_notify_subscribe_action(rtpe_redis_notify, UNSUBSCRIBE_KEYSPACE, uint_keyspace_db);
 		g_queue_remove(&rtpe_config.redis_subscribed_keyspaces, l->data);
 		streambuf_printf(replybuffer, "Successfully unsubscribed from keyspace %lu.\n", uint_keyspace_db);
 

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -12,6 +12,10 @@
 #include <sys/epoll.h>
 #include <glib.h>
 #include <sys/time.h>
+#include <main.h>
+#include <redis.h>
+#include <hiredis/adapters/libevent.h>
+
 
 #include "aux.h"
 #include "obj.h"
@@ -522,6 +526,10 @@ void poller_timer_loop(void *d) {
 
 now:
 		gettimeofday(&rtpe_now, NULL);
+		if (rtpe_redis_write && (rtpe_redis_write->async_last + rtpe_config.redis_delete_async_interval <= rtpe_now.tv_sec)) {
+			redis_async_event_base_action(rtpe_redis_write, EVENT_BASE_LOOPBREAK);
+			rtpe_redis_write->async_last = rtpe_now.tv_sec;
+		}
 		poller_timers_run(p);
 	}
 }

--- a/include/main.h
+++ b/include/main.h
@@ -70,6 +70,8 @@ struct rtpengine_config {
 	int			redis_disable_time;
 	int			redis_cmd_timeout;
 	int			redis_connect_timeout;
+	int			redis_delete_async;
+	int			redis_delete_async_interval;
 	char			*redis_auth;
 	char			*redis_write_auth;
 	int			num_threads;

--- a/include/redis.h
+++ b/include/redis.h
@@ -61,6 +61,12 @@ struct redis {
 	int		no_redis_required;
 	int		consecutive_errors;
 	time_t	restore_tick;
+
+	struct event_base        *async_ev;
+	struct redisAsyncContext *async_ctx;
+	mutex_t                   async_lock;
+	GQueue                    async_queue;
+	int                       async_last;
 };
 
 struct redis_hash {
@@ -77,9 +83,6 @@ struct redis_list {
 extern struct redis		*rtpe_redis;
 extern struct redis		*rtpe_redis_write;
 extern struct redis		*rtpe_redis_notify;
-
-extern struct event_base	*rtpe_redis_notify_event_base;
-extern struct redisAsyncContext *rtpe_redis_notify_async_context;
 
 
 
@@ -99,6 +102,7 @@ INLINE gboolean g_hash_table_insert_check(GHashTable *h, gpointer k, gpointer v)
 #define rlog(l, x...) ilog(l | LOG_FLAG_RESTORE, x)
 
 void redis_notify_loop(void *d);
+void redis_delete_async_loop(void *d);
 
 
 struct redis *redis_new(const endpoint_t *, int, const char *, enum redis_role, int);
@@ -108,8 +112,8 @@ void redis_update(struct call *, struct redis *);
 void redis_update_onekey(struct call *c, struct redis *r);
 void redis_delete(struct call *, struct redis *);
 void redis_wipe(struct redis *);
-int redis_notify_event_base_action(enum event_base_action);
-int redis_notify_subscribe_action(enum subscribe_action action, int keyspace);
+int redis_async_event_base_action(struct redis *r, enum event_base_action);
+int redis_notify_subscribe_action(struct redis *r, enum subscribe_action action, int keyspace);
 int redis_set_timeout(struct redis* r, int timeout);
 int redis_reconnect(struct redis* r);
 


### PR DESCRIPTION
Add a new thread to handle async deletes, using libevent, when enabled by config; default is disabled.

Note that when redis disconnects, deletes are currently lost.

@rfuchs let me know what you think of this PR.