### PR TITLE
EL packaging: Build with various FreeSWITCH package names for spandsp

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -17,7 +17,7 @@ BuildRequires:	glib2-devel libcurl-devel openssl-devel pcre-devel
 BuildRequires:	xmlrpc-c-devel zlib-devel hiredis-devel
 BuildRequires:	libpcap-devel libevent-devel json-glib-devel 
 BuildRequires:	gperf perl-IPC-Cmd
-BuildRequires:  spandsp-devel
+BuildRequires:  pkgconfig(spandsp)
 Requires(pre):	shadow-utils
 
 %if 0%{?with_transcoding} > 0


### PR DESCRIPTION
FreeSWITCH >= 1.10.5 has two packages names: spandsp or spandsp3.

As of 2020-09-08,  FreeSWITCH provides for EL systems:
- spandsp-devel-1.99.0-15.a6266f2259.x86_64.rpm
- spandsp3-devel-3.0.0-25.6ec23e5a7e.x86_64.rpm

They both provide `pkgconfig(spandsp)`, but unfortunately, spandsp3-devel does not provide `spandsp-devel` to act as a substitute.

The package from EPEL also provides `pkgconfig(spandsp)`, so this PR shouldn't break existing builds.

