### PR TITLE
Fix compilation when transcoding disabled

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -63,6 +63,7 @@ CFLAGS+=	$(shell pkg-config xmlrpc_client --cflags 2> /dev/null || xmlrpc-c-conf
 CFLAGS+=	$(shell pkg-config xmlrpc --cflags 2> /dev/null)
 CFLAGS+=	$(shell pkg-config xmlrpc_util --cflags 2> /dev/null)
 CFLAGS+=	$(shell pkg-config --cflags json-glib-1.0)
+CFLAGS+=	$(shell pkg-config --cflags libwebsockets)
 ifeq ($(with_iptables_option),yes)
 CFLAGS+=	$(shell pkg-config --cflags libiptc)
 CFLAGS+=	-DWITH_IPTABLES_OPTION
@@ -76,7 +77,6 @@ CFLAGS+=	$(shell pkg-config --cflags libavutil)
 CFLAGS+=	$(shell pkg-config --cflags libswresample)
 CFLAGS+=	$(shell pkg-config --cflags libavfilter)
 CFLAGS+=	$(shell pkg-config --cflags spandsp)
-CFLAGS+=	$(shell pkg-config --cflags libwebsockets)
 CFLAGS+=	-DWITH_TRANSCODING
 ifeq ($(have_bcg729),yes)
 CFLAGS+=	-DHAVE_BCG729
@@ -108,6 +108,7 @@ LDLIBS+=	$(shell pkg-config xmlrpc --libs 2> /dev/null)
 LDLIBS+=	$(shell pkg-config xmlrpc_util --libs 2> /dev/null)
 LDLIBS+=	-lhiredis
 LDLIBS+=	$(shell pkg-config --libs json-glib-1.0)
+LDLIBS+=	$(shell pkg-config --libs libwebsockets)
 ifeq ($(with_iptables_option),yes)
 LDLIBS+=	$(shell pkg-config --libs libiptc)
 endif
@@ -118,7 +119,6 @@ LDLIBS+=	$(shell pkg-config --libs libavutil)
 LDLIBS+=	$(shell pkg-config --libs libswresample)
 LDLIBS+=	$(shell pkg-config --libs libavfilter)
 LDLIBS+=	$(shell pkg-config --libs spandsp)
-LDLIBS+=	$(shell pkg-config --libs libwebsockets)
 ifeq ($(have_bcg729),yes)
 LDLIBS+=	$(bcg729_lib)
 endif

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -860,8 +860,8 @@ static void call_ng_flags_flags(struct sdp_ng_flags *out, str *s, void *dummy) {
 					return;
 				if (call_ng_flags_prefix(out, s, "T.38-", ng_t38_option, NULL))
 					return;
-#endif
 			}
+#endif
 
 			ilog(LOG_WARN, "Unknown flag encountered: '" STR_FORMAT "'",
 					STR_FMT(s));

--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2238,6 +2238,7 @@ static void __rtp_payload_type_add_name(GHashTable *ht, struct rtp_payload_type 
 	q = g_hash_table_lookup_queue_new(ht, str_dup(&pt->encoding_with_params), free);
 	g_queue_push_tail(q, GUINT_TO_POINTER(pt->payload_type));
 }
+#ifdef WITH_TRANSCODING
 static void __insert_codec_tracker(struct call_media *media, GList *link) {
 	struct rtp_payload_type *pt = link->data;
 	struct codec_tracker *sct = media->codec_tracker;
@@ -2261,6 +2262,7 @@ static void __insert_codec_tracker(struct call_media *media, GList *link) {
 		g_queue_push_tail(entries, link);
 	}
 }
+#endif
 static void __queue_insert_supp(GQueue *q, struct rtp_payload_type *pt, int supp_check,
 		struct codec_tracker *sct)
 {
@@ -2295,7 +2297,9 @@ static void __queue_insert_supp(GQueue *q, struct rtp_payload_type *pt, int supp
 void __rtp_payload_type_add_recv(struct call_media *media, struct rtp_payload_type *pt, int supp_check) {
 	if (!pt)
 		return;
+#ifdef WITH_TRANSCODING
 	ensure_codec_def(pt, media);
+#endif
 	if (proto_is_not_rtp(media->protocol)) {
 		payload_type_free(pt);
 		return;
@@ -2407,6 +2411,7 @@ static void __codec_options_set(struct call *call, struct rtp_payload_type *pt, 
 	if (__codec_options_set1(call, pt, &pt->encoding, codec_set))
 		return;
 }
+#ifdef WITH_TRANSCODING
 static void codec_tracker_destroy(struct codec_tracker **sct) {
 	if (!*sct)
 		return;
@@ -2524,6 +2529,7 @@ void codec_tracker_finish(struct call_media *media) {
 	g_list_free(clockrates);
 	codec_tracker_destroy(&media->codec_tracker);
 }
+#endif
 int __codec_ht_except(int all_flag, GHashTable *yes_ht, GHashTable *no_ht, struct rtp_payload_type *pt) {
 	int do_this = 0;
 	if (all_flag)
@@ -2593,7 +2599,9 @@ void codec_rtp_payload_types(struct call_media *media, struct call_media *other_
 		if (__codec_ht_except(strip_all, flags->codec_strip, flags->codec_except, pt)) {
 			ilog(LOG_DEBUG, "Stripping codec '" STR_FORMAT "'",
 					STR_FMT(&pt->encoding_with_params));
+#ifdef WITH_TRANSCODING
 			codec_touched(pt, media);
+#endif
 			GQueue *q = g_hash_table_lookup_queue_new(stripped, str_dup(&pt->encoding), free);
 			g_queue_push_tail(q, __rtp_payload_type_copy(pt));
 			q = g_hash_table_lookup_queue_new(stripped, str_dup(&pt->encoding_with_params), free);
@@ -2607,7 +2615,9 @@ void codec_rtp_payload_types(struct call_media *media, struct call_media *other_
 		if (__codec_ht_except(mask_all, flags->codec_mask, flags->codec_except, pt)) {
 			ilog(LOG_DEBUG, "Masking codec '" STR_FORMAT "'",
 					STR_FMT(&pt->encoding_with_params));
+#ifdef WITH_TRANSCODING
 			codec_touched(pt, media);
+#endif
 			GQueue *q = g_hash_table_lookup_queue_new(masked, str_dup(&pt->encoding), free);
 			g_queue_push_tail(q, __rtp_payload_type_copy(pt));
 			q = g_hash_table_lookup_queue_new(masked, str_dup(&pt->encoding_with_params), free);
@@ -2635,12 +2645,16 @@ void codec_rtp_payload_types(struct call_media *media, struct call_media *other_
 			}
 			ilog(LOG_DEBUG, "Eliminating asymmetric inbound codec " STR_FORMAT,
 					STR_FMT(&pt->encoding_with_params));
+#ifdef WITH_TRANSCODING
 			codec_touched(pt, other_media);
+#endif
 			l = __delete_receiver_codec(other_media, l);
 		}
 	}
 
+#ifdef WITH_TRANSCODING
 	__single_codec(media, flags);
+#endif
 
 #ifdef WITH_TRANSCODING
 	// add transcode codecs

--- a/lib/codeclib.h
+++ b/lib/codeclib.h
@@ -340,6 +340,7 @@ INLINE int decoder_event(decoder_t *dec, enum codec_event event, void *ptr) {
 // stubs
 struct codec_def_s {
 	int dtmf;
+	int supplemental;
 };
 struct packet_sequencer_s {
 };


### PR DESCRIPTION
Fix it by escaping newly added code with #ifdef WITH_TRANSCODING.

Also in the Makefile, I've moved LDFLAGS and CFLAGS outside transcoding check; alternativeley could have also guarded websocket #include with  #ifdef WITH_TRANSCODING.

Please let me know if this is ok.