### PR TITLE
RTT per call leg

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1536,6 +1536,7 @@ static void ng_stats_ssrc_mos_entry_common(bencode_item_t *subent, struct ssrc_s
 {
 	bencode_dictionary_add_integer(subent, "MOS", sb->mos / div);
 	bencode_dictionary_add_integer(subent, "round-trip time", sb->rtt / div);
+	bencode_dictionary_add_integer(subent, "round-trip time leg", sb->rtt_leg / div);
 	bencode_dictionary_add_integer(subent, "jitter", sb->jitter / div);
 	bencode_dictionary_add_integer(subent, "packet loss", sb->packetloss / div);
 }

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -357,6 +357,7 @@ void ssrc_receiver_report(struct call_media *m, const struct ssrc_receiver_repor
 	*ssb = (struct ssrc_stats_block) {
 		.jitter = jitter,
 		.rtt = rtt + other_e->last_rtt,
+		.rtt_leg = rtt,
 		.reported = *tv,
 		.packetloss = (unsigned int) rr->fraction_lost * 100 / 256,
 	};
@@ -386,6 +387,7 @@ void ssrc_receiver_report(struct call_media *m, const struct ssrc_receiver_repor
 	// running tally
 	other_e->average_mos.jitter += ssb->jitter;
 	other_e->average_mos.rtt += ssb->rtt;
+	other_e->average_mos.rtt_leg += ssb->rtt_leg;
 	other_e->average_mos.packetloss += ssb->packetloss;
 	other_e->average_mos.mos += ssb->mos;
 

--- a/include/ssrc.h
+++ b/include/ssrc.h
@@ -71,6 +71,7 @@ struct ssrc_stats_block {
 	struct timeval reported;
 	u_int64_t jitter; // ms
 	u_int64_t rtt; // us - combined from both sides
+	u_int32_t rtt_leg; // RTT only for the leg receiving the RTCP report
 	u_int64_t packetloss; // percent
 	u_int64_t mos; // nominal range of 10 - 50 for MOS values 1.0 to 5.0
 };


### PR DESCRIPTION
This will let us retrieve the RTT per call legs.

I also tested the integration into kamailio rtpengine module.
(I will make an MR if we do merge this new feature)


Test notes from Kamailio :

Test 1 :
With leg A (Caller) very far 250ms RTT from rtp-engine and leg B (Callee) 100ms RTT 
```
<script>: [QOS][Caller]rtt[370414us]rtt_leg[265979]
<script>: [QOS][Callee]rtt[303485us]rtt_leg[104435]
<script>: [QOS][Average]rtt[336949us]rtt_leg[185207]
```
Test 2:  
Both legs  94ms RTT 
```
<script>: [QOS][Caller]rtt[166813us]rtt_leg[92066]
<script>: [QOS][Callee]rtt[186408us]rtt_leg[94342]
<script>: [QOS][Average]rtt[176610us]rtt_leg[93204]
```



Kamailio config :
```
modparam("rtpengine", "mos_B_label_pv", "$avp(mos_B_label)")
modparam("rtpengine", "mos_max_roundtrip_B_pv", "$avp(mos_max_roundtrip_B)");
modparam("rtpengine", "mos_average_roundtrip_B_pv", "$avp(mos_average_roundtrip_B)");
modparam("rtpengine", "mos_average_roundtrip_leg_B_pv", "$avp(mos_average_roundtrip_leg_B)");

modparam("rtpengine", "mos_A_label_pv", "$avp(mos_A_label)")
modparam("rtpengine", "mos_max_roundtrip_A_pv", "$avp(mos_max_roundtrip_A)");
modparam("rtpengine", "mos_average_roundtrip_A_pv", "$avp(mos_average_roundtrip_A)");
modparam("rtpengine", "mos_average_roundtrip_leg_A_pv", "$avp(mos_average_roundtrip_leg_A)");

modparam("rtpengine", "mos_min_pv", "$avp(mos_min)")
modparam("rtpengine", "mos_max_roundtrip_pv", "$avp(mos_max_roundtrip)");
modparam("rtpengine", "mos_average_roundtrip_pv", "$avp(mos_average_roundtrip)");
modparam("rtpengine", "mos_average_roundtrip_leg_pv", "$avp(mos_average_roundtrip_leg)");

route[QOS] {
	$avp(mos_A_label) = "legA";	
	$avp(mos_B_label) = "legB";	
	rtpengine_query();
	xinfo("[QOS][Caller]rtt[$avp(mos_average_roundtrip_A)us]rtt_leg[$avp(mos_average_roundtrip_leg_A)]\n");
	xinfo("[QOS][Callee]rtt[$avp(mos_average_roundtrip_B)us]rtt_leg[$avp(mos_average_roundtrip_leg_B)]\n");
	xinfo("[QOS][Average]rtt[$avp(mos_average_roundtrip)us]rtt_leg[$avp(mos_average_roundtrip_leg)]\n");
}
```



Additional note: I will also complete the WIP on QoS Rx per call leg without RTCP.
As requested I tested with the kernel module, there was no problem, I am getting closer.
https://github.com/jchavanton/rtpengine/pull/1
