### PR TITLE
Update call.c

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -1653,6 +1653,11 @@ static void __rtcp_mux_logic(const struct sdp_ng_flags *flags, struct call_media
 	if (flags->opmode == OP_ANSWER) {
 		/* default is to go with the client's choice, unless we were instructed not
 		 * to do that in the offer (see below) */
+		
+		/* if the consecutive answer is from different media endpoint, then we need to check if rtcp-mux was offered initially by client */
+                if (MEDIA_ISSET(media, RTCP_MUX))
+                    return;
+		
 		if (!MEDIA_ISSET(other_media, RTCP_MUX_OVERRIDE))
 			bf_copy_same(&media->media_flags, &other_media->media_flags, MEDIA_FLAG_RTCP_MUX);
 


### PR DESCRIPTION
If the consecutive answer is from different media endpoint (e.g. early media scenario with different media endpoint used for 183), then we are loosing RTCP_MUX_OVERRIDE, as it was set for the previous answer. We need to explicitly check if rtcp-mux was initially offered by the client.