### PR TITLE
Update jitter_buffer.c

### DIFF
--- a/daemon/jitter_buffer.c
+++ b/daemon/jitter_buffer.c
@@ -4,6 +4,7 @@
 #include "call.h"
 #include "codec.h"
 #include "main.h"
+#include "rtcplib.h"
 #include <math.h>
 #include <errno.h>
 
@@ -233,7 +234,7 @@ int buffer_packet(struct media_packet *mp, const str *s) {
 	rwlock_lock_r(&call->master_lock);
 
 	struct jitter_buffer *jb = mp->stream->jb;
-	if (!jb || jb->disabled)
+	if (!jb || jb->disabled || !PS_ISSET(mp->sfd->stream, RTP))
 		goto end;
 
 	if(jb->initial_pkts < INITIAL_PACKETS) { //Ignore initial Payload Type 126 if any
@@ -245,10 +246,10 @@ int buffer_packet(struct media_packet *mp, const str *s) {
 	if (!p)
 		goto end;
 
-	if ((p->mp.rtp->m_pt & 0x7f) >=72 && (p->mp.rtp->m_pt & 0x7f) <= 76){
-        	ilog(LOG_DEBUG, "Discard from JB. This is RTCP packet. SSRC %u Payload %d", ntohl(p->mp.rtp->ssrc), (p->mp.rtp->m_pt & 0x7f));
-        	goto end;
-    	}
+        if (PS_ISSET(mp->sfd->stream, RTCP) && rtcp_demux_is_rtcp((void *) &p->mp.raw)){
+            ilog(LOG_DEBUG, "Discarding from JB. This is RTCP packet. SSRC %u Payload %d", ntohl(p->mp.rtp->ssrc), (p->mp.rtp->m_pt & 0x7f));
+            goto end;
+        }
 	
 	ilog(LOG_DEBUG, "Handling JB packet on: %s:%d (RTP SSRC %u Payload: %d)", sockaddr_print_buf(&mp->stream->endpoint.address),
             mp->stream->endpoint.port, ntohl(p->mp.rtp->ssrc), (p->mp.rtp->m_pt & 0x7f));


### PR DESCRIPTION
Changed the way of excluding RTCP from being processed by JB.
For rtcp-mux, stream is both RTP and RTCP. That causes the situation when the first RTCP packet received is disabling Jitter Buffer. The proposition is to rely on check every packet and exclude the RTCP one from being processed in JB.