### PR TITLE
Fix error in xt_RTPENGINE.c introduced by commit 9a2dc5

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -3452,7 +3452,7 @@ static int send_proxy_packet6(struct sk_buff *skb, struct re_address *src, struc
 
 	skb->protocol = htons(ETH_P_IPV6);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,9) || \
-		(LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,78) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)) \
+		(LINUX_VERSION_CODE >= KERNEL_VERSION(5,4,78) && LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)) || \
 		(LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,158) && LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0))
 	if (ip6_route_me_harder(par->state->net, par->state->sk, skb))
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,10,0)


### PR DESCRIPTION
Fixes an error I got when trying to install the module via DKMS
```
make: Entering directory '/usr/src/kernels/4.18.0-240.1.1.el8_3.x86_64'
  CC [M]  /var/lib/dkms/ngcp-rtpengine/9.2.0.0+0~mr9.2.0.0-1.el8/build/xt_RTPENGINE.o
/var/lib/dkms/ngcp-rtpengine/9.2.0.0+0~mr9.2.0.0-1.el8/build/xt_RTPENGINE.c: In function ‘send_proxy_packet6’:
/var/lib/dkms/ngcp-rtpengine/9.2.0.0+0~mr9.2.0.0-1.el8/build/xt_RTPENGINE.c:3456:3: error: missing binary operator before token "("
   (LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,158) && LINUX_VERSION_CODE < KERNEL_VERSION(4,20,0))
```