### PR TITLE
Control ng tcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1956,6 +1956,13 @@ command. Sample return dictionary:
 	  "result": "ok"
 	}
 
+The *tcp-ng* Control Protocol
+=========================
+
+*rtpengine* also has support for *ng* control protocol where transport is
+TCP (If enabled in the config via the --listen-tcp-ng option). Everything
+said for UDP based *ng* protocol counts for TCP variant too.
+
 HTTP/WebSocket support
 ======================
 

--- a/daemon/bencode.c
+++ b/daemon/bencode.c
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
-
+#include <ctype.h>
 
 /* set to 0 for alloc debugging, e.g. through valgrind */
 #define BENCODE_MIN_BUFFER_PIECE_LEN	512

--- a/daemon/bencode.c
+++ b/daemon/bencode.c
@@ -709,7 +709,7 @@ static int __bencode_string(const char *s, int offset, int len) {
 	unsigned long long sl;
 	char *end;
 
-	for (pos = offset + 1; s[pos] != 0x3a && isdigit(s[pos]) && pos < len; ++pos);
+	for (pos = offset + 1; s[pos] != ':' && isdigit(s[pos]) && pos < len; ++pos);
 	if (pos == len)
 		return -1;
 
@@ -726,24 +726,24 @@ static int __bencode_string(const char *s, int offset, int len) {
 static int __bencode_integer(const char *s, int offset, int len) {
 	int pos;
 
-	if (s[offset + 1] == 0x2d) {
-		if (offset + 3 < len && s[offset + 2] == 0x30 && s[offset + 3] == 0x65) {
+	if (s[offset + 1] == '-') {
+		if (offset + 3 < len && s[offset + 2] == '0' && s[offset + 3] == 'e') {
 			return -2;
 		}
 		++offset;
 	}
 
-	if (s[offset + 1] == 0x65)
+	if (s[offset + 1] == 'e')
 		return -2;
 
-	if (s[offset + 1] == 0x30) {
-		if (offset + 2 < len && s[offset + 2] == 0x65)
+	if (s[offset + 1] == '0') {
+		if (offset + 2 < len && s[offset + 2] == 'e')
 			return offset + 3;
 		return -2;
 	}
 
-	for (pos = offset + 1; s[pos] != 0x65 && pos < len; ++pos) {
-		if (s[pos] < 0x30 || s[pos] > 0x39)
+	for (pos = offset + 1; s[pos] != 'e' && pos < len; ++pos) {
+		if (s[pos] < '0' || s[pos] > '9')
 			return -2;
 	}
 
@@ -756,7 +756,7 @@ static int __bencode_integer(const char *s, int offset, int len) {
 static int __bencode_next(const char *s, int offset, int len);
 
 static int __bencode_list(const char *s, int offset, int len) {
-	for (++offset; s[offset] != 0x65 && offset < len;) {
+	for (++offset; s[offset] != 'e' && offset < len;) {
 		offset = __bencode_next(s, offset, len);
 		if (offset < 0)
 			return offset;
@@ -769,7 +769,7 @@ static int __bencode_list(const char *s, int offset, int len) {
 }
 
 static int __bencode_dictionary(const char *s, int offset, int len) {
-	for (++offset; s[offset] != 0x65 && offset < len;) {
+	for (++offset; s[offset] != 'e' && offset < len;) {
 		offset = __bencode_string(s, offset - 1, len);
 		if (offset < 0)
 			return offset;
@@ -788,22 +788,22 @@ static int __bencode_next(const char *s, int offset, int len) {
 	if (offset >= len)
 		return -1;
 	switch(s[offset]) {
-		case 0x69:
+		case 'i':
 			return __bencode_integer(s, offset, len);
-		case 0x6c:
+		case 'l':
 			return __bencode_list(s, offset, len);
-		case 0x64:
+		case 'd':
 			return __bencode_dictionary(s, offset, len);
-		case 0x30:
-		case 0x31:
-		case 0x32:
-		case 0x33:
-		case 0x34:
-		case 0x35:
-		case 0x36:
-		case 0x37:
-		case 0x38:
-		case 0x39:
+		case '0':
+		case '1':
+		case '2':
+		case '3':
+		case '4':
+		case '5':
+		case '6':
+		case '7':
+		case '8':
+		case '9':
 			return __bencode_string(s, offset - 1, len);
 	}
 	return -2;

--- a/daemon/rtpengine.pod
+++ b/daemon/rtpengine.pod
@@ -4,7 +4,7 @@ rtpengine - NGCP proxy for RTP and other UDP based media traffic
 
 =head1 SYNOPSIS
 
-B<rtpengine> B<--interface>=I<addr>... B<--listen-tcp>|B<--listen-udp>|B<--listen-ng>=I<addr>... [I<option>...]
+B<rtpengine> B<--interface>=I<addr>... B<--listen-tcp>|B<--listen-udp>|B<--listen-ng>|B<--listen-tcp-ng>=I<addr>... [I<option>...]
 
 =head1 DESCRIPTION
 
@@ -100,7 +100,9 @@ See the section L<INTERFACES> just below for details.
 
 =item B<-n>, B<--listen-ng=>[I<IP46>B<:>]I<PORT>
 
-These options each enable one of the 3 available control protocols if given
+=item B<-n>, B<--listen-tcp-ng=>[I<IP46>B<:>]I<PORT>
+
+These options each enable one of the 4 available control protocols if given
 and each take either just a port number as argument, or an I<address:port>
 pair, separated by colon.
 At least one of these 3 options must be given.
@@ -119,6 +121,8 @@ With this protocol, the complete SDP body is passed to B<rtpengine>,
 rewritten and passed back to B<Kamailio>.
 Several additional features are available with this protocol, such as
 ICE handling, SRTP bridging, etc.
+
+The B<tcp-ng> protocol is in fact the B<ng> protocol but transported over TCP.
 
 It is recommended to specify not only a local port number, but also
 B<127.0.0.1> as interface to bind to.

--- a/include/bencode.h
+++ b/include/bencode.h
@@ -301,8 +301,8 @@ INLINE bencode_item_t *bencode_decode_expect(bencode_buffer_t *buf, const char *
 /* Identical to bencode_decode_expect() but takes a "str" argument. */
 INLINE bencode_item_t *bencode_decode_expect_str(bencode_buffer_t *buf, const str *s, bencode_type_t expect);
 
-
-
+/* Returns the number of bytes that could successfully be decoded from 's', -1 if more bytes are needed or -2 on error */
+int bencode_valid(const char *s, int len);
 
 
 /*** DICTIONARY LOOKUP & EXTRACTION ***/

--- a/include/control_ng.h
+++ b/include/control_ng.h
@@ -5,8 +5,8 @@
 #include "udp_listener.h"
 #include "socket.h"
 #include "str.h"
+#include "tcp_listener.h"
 #include "bencode.h"
-
 
 struct poller;
 
@@ -48,6 +48,7 @@ struct control_ng_stats {
 struct control_ng {
 	struct obj obj;
 	socket_t udp_listeners[2];
+	struct streambuf_listener tcp_listeners[2];
 	struct poller *poller;
 };
 
@@ -62,6 +63,8 @@ extern const char *ng_command_strings[NGC_COUNT];
 extern const char *ng_command_strings_short[NGC_COUNT];
 
 struct control_ng *control_ng_new(struct poller *, endpoint_t *, unsigned char);
+struct control_ng *control_ng_tcp_new(struct poller *, endpoint_t *, struct control_ng *);
+void notify_ng_tcp_clients(str *);
 void control_ng_init(void);
 void control_ng_cleanup(void);
 int control_ng_process(str *buf, const endpoint_t *sin, char *addr,

--- a/include/main.h
+++ b/include/main.h
@@ -54,6 +54,7 @@ struct rtpengine_config {
 	endpoint_t		tcp_listen_ep;
 	endpoint_t		udp_listen_ep;
 	endpoint_t		ng_listen_ep;
+	endpoint_t		ng_tcp_listen_ep;
 	endpoint_t		cli_listen_ep;
 	endpoint_t		redis_ep;
 	endpoint_t		redis_write_ep;

--- a/t/Makefile
+++ b/t/Makefile
@@ -72,7 +72,7 @@ LIBSRCS+=	codeclib.c resample.c socket.c streambuf.c dtmflib.c
 DAEMONSRCS+=	codec.c call.c ice.c kernel.c media_socket.c stun.c bencode.c poller.c \
 		dtls.c recording.c statistics.c rtcp.c redis.c iptables.c graphite.c \
 		cookie_cache.c udp_listener.c homer.c load.c cdr.c dtmf.c timerthread.c \
-		media_player.c jitter_buffer.c t38.c
+		media_player.c jitter_buffer.c t38.c tcp_listener.c
 HASHSRCS+=	call_interfaces.c control_ng.c sdp.c
 endif
 
@@ -164,7 +164,7 @@ transcode-test:	transcode-test.o $(COMMONOBJS) codeclib.o resample.o codec.o ssr
 	rtcp.o redis.o iptables.o graphite.o call_interfaces.strhash.o sdp.strhash.o rtp.o crypto.o \
 	control_ng.strhash.o \
 	streambuf.o cookie_cache.o udp_listener.o homer.o load.o cdr.o dtmf.o timerthread.o \
-	media_player.o jitter_buffer.o dtmflib.o t38.o
+	media_player.o jitter_buffer.o dtmflib.o t38.o tcp_listener.o
 
 payload-tracker-test: payload-tracker-test.o $(COMMONOBJS) ssrc.o aux.o auxlib.o rtp.o crypto.o codeclib.o \
 	resample.o dtmflib.o


### PR DESCRIPTION
This patch adds support for control-ng over TCP; we feel this to be an important feature, it was tested in our production environment for some time and the results are encouraging.