### PR TITLE
Implement poller per thread in order to fix packet order.

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -2223,7 +2223,7 @@ static void stream_fd_free(void *p) {
 struct stream_fd *stream_fd_new(socket_t *fd, struct call *call, const struct local_intf *lif) {
 	struct stream_fd *sfd;
 	struct poller_item pi;
-	struct poller *p;
+	struct poller *p = rtpe_poller;
 
 	sfd = obj_alloc0("stream_fd", sizeof(*sfd), stream_fd_free);
 	sfd->unique_id = g_queue_get_length(&call->stream_fds);
@@ -2241,7 +2241,8 @@ struct stream_fd *stream_fd_new(socket_t *fd, struct call *call, const struct lo
 	pi.readable = stream_fd_readable;
 	pi.closed = stream_fd_closed;
 
-	p = poller_map_get(rtpe_poller_map);
+	if (rtpe_config.poller_per_thread)
+		p = poller_map_get(rtpe_poller_map);
 	if (p) {
 		if (poller_add_item(p, &pi))
 			ilog(LOG_ERR, "Failed to add stream_fd to poller");

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -2223,6 +2223,7 @@ static void stream_fd_free(void *p) {
 struct stream_fd *stream_fd_new(socket_t *fd, struct call *call, const struct local_intf *lif) {
 	struct stream_fd *sfd;
 	struct poller_item pi;
+	struct poller *p;
 
 	sfd = obj_alloc0("stream_fd", sizeof(*sfd), stream_fd_free);
 	sfd->unique_id = g_queue_get_length(&call->stream_fds);
@@ -2240,8 +2241,11 @@ struct stream_fd *stream_fd_new(socket_t *fd, struct call *call, const struct lo
 	pi.readable = stream_fd_readable;
 	pi.closed = stream_fd_closed;
 
-	if (poller_add_item(rtpe_poller, &pi))
-		ilog(LOG_ERR, "Failed to add stream_fd to poller");
+	p = poller_map_get(rtpe_poller_map);
+	if (p) {
+		if (poller_add_item(p, &pi))
+			ilog(LOG_ERR, "Failed to add stream_fd to poller");
+	}
 
 	return sfd;
 }

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -598,18 +598,6 @@ now:
 	}
 }
 
-static void sleep_ms(int ms) {
-	struct timespec deadline;
-        long next_tick;
-        clock_gettime(CLOCK_MONOTONIC, &deadline);
-
-        next_tick = (deadline.tv_sec * 1000000000L + deadline.tv_nsec) + ms * 1000000;
-        deadline.tv_sec = next_tick / 1000000000L;
-        deadline.tv_nsec = next_tick % 1000000000L;
-
-        clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &deadline, NULL);
-}
-
 void poller_loop(void *d) {
 	struct poller_map *map = d;
 	poller_map_add(map);
@@ -618,7 +606,7 @@ void poller_loop(void *d) {
 	while (!rtpe_shutdown) {
 		int ret = poller_poll(p, 100);
 		if (ret < 0)
-			sleep_ms(20);
+			usleep(20 * 1000);
 	}
 }
 

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -603,16 +603,15 @@ void poller_loop(void *d) {
 	poller_map_add(map);
 	struct poller *p = poller_map_get(map);
 
-	while (!rtpe_shutdown) {
-		int ret = poller_poll(p, 100);
-		if (ret < 0)
-			usleep(20 * 1000);
-	}
+	poller_loop2(p);
 }
 
 void poller_loop2(void *d) {
 	struct poller *p = d;
 
-	while (!rtpe_shutdown)
-		poller_poll(p, 100);
+	while (!rtpe_shutdown) {
+		int ret = poller_poll(p, 100);
+		if (ret < 0)
+			usleep(20 * 1000);
+	}
 }

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -620,7 +620,7 @@ void poller_loop(void *d) {
 	while (!rtpe_shutdown) {
 		int ret = poller_poll(p, 100);
 		if (ret < 0)
-			sleep_ms(10);
+			sleep_ms(20);
 	}
 }
 

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -91,9 +91,7 @@ struct poller *poller_map_get(struct poller_map *map) {
 	p = g_hash_table_lookup(map->table, (gpointer)tid);
 	if (!p) {
 		gpointer *arr = g_hash_table_get_keys_as_array(map->table, NULL);
-		GRand *rnd = g_rand_new();
-		p = g_hash_table_lookup(map->table, arr[g_rand_int_range(rnd, 0, g_hash_table_size(map->table))]);
-		g_rand_free(rnd);
+		p = g_hash_table_lookup(map->table, arr[ssl_random() % g_hash_table_size(map->table)]);
 	}
 	mutex_unlock(&map->lock);
 	return p;

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -90,6 +90,7 @@ struct poller *poller_map_get(struct poller_map *map) {
 	if (!p) {
 		gpointer *arr = g_hash_table_get_keys_as_array(map->table, NULL);
 		p = g_hash_table_lookup(map->table, arr[ssl_random() % g_hash_table_size(map->table)]);
+		g_free(arr);
 	}
 	mutex_unlock(&map->lock);
 	return p;

--- a/daemon/rtpengine.pod
+++ b/daemon/rtpengine.pod
@@ -848,6 +848,14 @@ information.
 Always sets the option B<reorder-codecs> in answer messages as described in the
 F<README.md>.
 
+=item B<--poller-per-thread>
+
+Enable 'poller per thread' functionality: for every worker thread (see the
+--num-threads option) a poller will be created. With this option on, it is
+guaranteed that only a single thread will ever read from a particular socket,
+thus maintaining the order of the packets. Might help when having issues with
+DTMF packets (RFC 2833).
+
 =back
 
 =head1 INTERFACES

--- a/include/main.h
+++ b/include/main.h
@@ -116,6 +116,7 @@ struct rtpengine_config {
 	str			cn_payload;
 	int			reorder_codecs;
 	char			*software_id;
+	int			poller_per_thread;
 };
 
 

--- a/include/main.h
+++ b/include/main.h
@@ -120,8 +120,10 @@ struct rtpengine_config {
 
 
 struct poller;
-extern struct poller *rtpe_poller; // main global poller instance XXX convert to struct instead of pointer?
+struct poller_map;
 
+extern struct poller *rtpe_poller; // main global poller instance XXX convert to struct instead of pointer?
+extern struct poller_map *rtpe_poller_map;
 
 extern struct rtpengine_config rtpe_config;
 extern struct rtpengine_config initial_rtpe_config;

--- a/include/poller.h
+++ b/include/poller.h
@@ -28,9 +28,12 @@ struct poller_item {
 };
 
 struct poller;
-
+struct poller_map;
 
 struct poller *poller_new(void);
+struct poller_map *poller_map_new(void);
+struct poller *poller_map_get(struct poller_map *);
+void poller_map_free(struct poller_map **);
 void poller_free(struct poller **);
 int poller_add_item(struct poller *, struct poller_item *);
 int poller_update_item(struct poller *, struct poller_item *);
@@ -43,6 +46,7 @@ void poller_error(struct poller *, void *);
 int poller_poll(struct poller *, int);
 void poller_timer_loop(void *);
 void poller_loop(void *);
+void poller_loop2(void *);
 
 int poller_add_timer(struct poller *, void (*)(void *), struct obj *);
 int poller_del_timer(struct poller *, void (*)(void *), struct obj *);

--- a/t/test-transcode.c
+++ b/t/test-transcode.c
@@ -10,6 +10,7 @@ int _log_facility_cdr;
 int _log_facility_dtmf;
 struct rtpengine_config rtpe_config;
 struct poller *rtpe_poller;
+struct poller_map *rtpe_poller_map;
 GString *dtmf_logs;
 
 static str *sdup(char *s) {


### PR DESCRIPTION
With this patch we implemented a poller per thread which will guarantee the correct order of packets being read and sent. In our production environment we noticed that sometimes DTMF packets (RFC 2833) are being sent from RTPEngine in an incorrect order, even though they were delivered in the correct one. Our conclusion was that this was caused by the fact that different threads are reading (and thus sending) DTMF packets from the same socket. Having a poller per thread, we are certain that only a single thread will ever read from a single socket, thus maintaining the correct packet order.