### PR TITLE
max-mos: is often invalid when RTCP was not received on both legs 

### DIFF
--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -60,6 +60,9 @@ static void ssrc_entry_put(void *ep) {
 
 // returned as mos * 10 (i.e. 10 - 50 for 1.0 to 5.0)
 static void mos_calc(struct ssrc_stats_block *ssb) {
+	if (!ssb->rtt)
+		return; // can not compute the MOS-CQ unless we have a valid RTT
+
 	// as per https://www.pingman.com/kb/article/how-is-mos-calculated-in-pingplotter-pro-50.html
 	int eff_rtt = ssb->rtt / 1000 + ssb->jitter * 2 + 10;
 	double r; // XXX can this be done with int math?
@@ -359,7 +362,7 @@ void ssrc_receiver_report(struct call_media *m, const struct ssrc_receiver_repor
 	struct ssrc_stats_block *ssb = g_slice_alloc(sizeof(*ssb));
 	*ssb = (struct ssrc_stats_block) {
 		.jitter = jitter,
-		.rtt = rtt + other_e->last_rtt,
+		.rtt = other_e->last_rtt ? (rtt + other_e->last_rtt) : 0,
 		.rtt_leg = rtt,
 		.reported = *tv,
 		.packetloss = (unsigned int) rr->fraction_lost * 100 / 256,


### PR DESCRIPTION
Since we are using RTT mos-cq (conversational quality), we should not compute it when we have only the RTT from one
leg.

What is happening is that almost everytime you have significant latency, the min-mos is the first one and is not accurate ... 

We should consider this mos-cq invalid.

Further actions :
- add MOS-LQ (the mos that does not consider RTT)
- modify Kamailio rtpengine module to not select mos = 0 as the lower mos.

```
if (decode_mos_vals_dict(&vals_decoded, ssrc_dict, "lowest MOS")) {
        if (vals_decoded.mos > 0 && vals_decoded.mos < min_vals.mos)
                min_vals = vals_decoded;
}
```

Speaking about this, this seems like a good article for more context.
https://archive.eetasia.com/www.eetasia.com/ARTICLES/2005OCT/B/2005OCT03_RFD_NETD_TA.pdf?SOURCES=DOWNLOAD
