### PR TITLE
Add stats for ipv4/ipv6/mixed media calls

### DIFF
--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -429,6 +429,9 @@ static void cli_incoming_list_numsessions(str *instr, struct cli_writer *cw) {
        cw->cw_printf(cw, "Current sessions total: %i\n", g_hash_table_size(rtpe_callhash));
        rwlock_unlock_r(&rtpe_callhash_lock);
        cw->cw_printf(cw, "Current transcoded media: "UINT64F"\n", atomic64_get(&rtpe_stats.transcoded_media));
+       cw->cw_printf(cw, "Current sessions ipv4 only media: %li\n", atomic64_get(&rtpe_stats.ipv4_sessions));
+       cw->cw_printf(cw, "Current sessions ipv6 only media: %li\n", atomic64_get(&rtpe_stats.ipv6_sessions));
+       cw->cw_printf(cw, "Current sessions ip mixed  media: %li\n", atomic64_get(&rtpe_stats.mixed_sessions));
 }
 
 static void cli_incoming_list_maxsessions(str *instr, struct cli_writer *cw) {

--- a/daemon/graphite.c
+++ b/daemon/graphite.c
@@ -195,6 +195,9 @@ static int send_graphite_data(struct totalstats *sent_data) {
 	GPF("current_sessions_own "UINT64F, ts->own_sessions);
 	GPF("current_sessions_foreign "UINT64F, ts->foreign_sessions);
 	GPF("current_transcoded_media "UINT64F, atomic64_get(&rtpe_stats.transcoded_media));
+	GPF("current_sessions_ipv4 "UINT64F, atomic64_get(&rtpe_stats.ipv4_sessions));
+	GPF("current_sessions_ipv6 "UINT64F, atomic64_get(&rtpe_stats.ipv6_sessions));
+	GPF("current_sessions_mixed "UINT64F, atomic64_get(&rtpe_stats.mixed_sessions));
 	GPF("nopacket_relayed_sess "UINT64F, atomic64_get_na(&ts->total_nopacket_relayed_sess));
 	GPF("oneway_stream_sess "UINT64F, atomic64_get_na(&ts->total_oneway_stream_sess));
 	GPF("regular_term_sess "UINT64F, atomic64_get_na(&ts->total_regular_term_sess));

--- a/include/call.h
+++ b/include/call.h
@@ -52,6 +52,11 @@ enum call_opmode {
 	OP_OTHER,
 };
 
+enum call_media_counted {
+	CMC_INCREMENT = 0,
+	CMC_DECREMENT,
+};
+
 enum call_stream_state {
 	CSS_UNKNOWN = 0,
 	CSS_SHUTDOWN,
@@ -416,6 +421,13 @@ struct call {
 
 	struct recording 	*recording;
 	str			metadata;
+
+	// ipv4/ipv6 media flags
+	unsigned int		is_ipv4_media_offer:1;
+	unsigned int		is_ipv6_media_offer:1;
+	unsigned int		is_ipv4_media_answer:1;
+	unsigned int		is_ipv6_media_answer:1;
+	unsigned int		is_call_media_counted:1;
 
 	unsigned int		block_dtmf:1;
 	unsigned int		block_media:1;

--- a/include/statistics.h
+++ b/include/statistics.h
@@ -20,6 +20,9 @@ struct stats {
 	atomic64			answers;
 	atomic64			deletes;
 	atomic64			transcoded_media;
+	atomic64			ipv4_sessions;
+	atomic64			ipv6_sessions;
+	atomic64			mixed_sessions;
 };
 
 
@@ -125,6 +128,7 @@ extern mutex_t rtpe_codec_stats_lock;
 extern GHashTable *rtpe_codec_stats;
 
 void statistics_update_oneway(struct call *);
+void statistics_update_ip46_inc_dec(struct call *, int op);
 void statistics_update_foreignown_dec(struct call *);
 void statistics_update_foreignown_inc(struct call* c);
 void statistics_update_totals(struct packet_stream *) ;


### PR DESCRIPTION
Also Send stats for ipv4/ipv6/mixed media calls to graphite