### PR TITLE
Mos average fix

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2566,13 +2566,15 @@ void call_destroy(struct call *c) {
 
 		if (!se->stats_blocks.length || !se->lowest_mos || !se->highest_mos)
 			continue;
+		int mos_samples = (se->stats_blocks.length - se->no_mos_count);
+		if (mos_samples < 1) mos_samples = 1;
 
 		ilog(LOG_INFO, "--- SSRC %s%" PRIx32 "%s", FMT_M(se->h.ssrc));
 		ilog(LOG_INFO, "------ Average MOS %" PRIu64 ".%" PRIu64 ", "
 				"lowest MOS %" PRIu64 ".%" PRIu64 " (at %u:%02u), "
 				"highest MOS %" PRIu64 ".%" PRIu64 " (at %u:%02u)",
-			se->average_mos.mos / se->stats_blocks.length / 10,
-			se->average_mos.mos / se->stats_blocks.length % 10,
+			se->average_mos.mos / mos_samples / 10,
+			se->average_mos.mos / mos_samples % 10,
 			se->lowest_mos->mos / 10,
 			se->lowest_mos->mos % 10,
 			(unsigned int) (timeval_diff(&se->lowest_mos->reported, &c->created) / 1000000) / 60,

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1730,7 +1730,10 @@ static void ng_stats_ssrc(bencode_item_t *dict, struct ssrc_hash *ht) {
 		if (!se->stats_blocks.length || !se->lowest_mos || !se->highest_mos)
 			continue;
 
-		ng_stats_ssrc_mos_entry_dict_avg(ent, "average MOS", &se->average_mos, se->stats_blocks.length);
+		int mos_samples = se->stats_blocks.length - se->no_mos_count;
+		if (mos_samples < 1) mos_samples = 1;
+
+		ng_stats_ssrc_mos_entry_dict_avg(ent, "average MOS", &se->average_mos, mos_samples);
 		ng_stats_ssrc_mos_entry_dict(ent, "lowest MOS", se->lowest_mos);
 		ng_stats_ssrc_mos_entry_dict(ent, "highest MOS", se->highest_mos);
 

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -382,17 +382,21 @@ void ssrc_receiver_report(struct call_media *m, const struct ssrc_receiver_repor
 
 	g_queue_push_tail(&other_e->stats_blocks, ssb);
 
-	if (G_UNLIKELY(!other_e->lowest_mos) || ssb->mos < other_e->lowest_mos->mos)
+	if (ssb->mos && ((G_UNLIKELY(!other_e->lowest_mos) || ssb->mos < other_e->lowest_mos->mos)))
 		other_e->lowest_mos = ssb;
 	if (G_UNLIKELY(!other_e->highest_mos) || ssb->mos > other_e->highest_mos->mos)
 		other_e->highest_mos = ssb;
 
 	// running tally
-	other_e->average_mos.jitter += ssb->jitter;
-	other_e->average_mos.rtt += ssb->rtt;
-	other_e->average_mos.rtt_leg += ssb->rtt_leg;
-	other_e->average_mos.packetloss += ssb->packetloss;
-	other_e->average_mos.mos += ssb->mos;
+	if (!ssb->mos) { // when we do not have the RTT for both legs, we have no MOS
+		other_e->no_mos_count++;
+	} else {
+		other_e->average_mos.jitter += ssb->jitter;
+		other_e->average_mos.mos += ssb->mos;
+		other_e->average_mos.rtt += ssb->rtt;
+		other_e->average_mos.rtt_leg += ssb->rtt_leg;
+		other_e->average_mos.packetloss += ssb->packetloss;
+	}
 
 	goto out_ul_oe;
 

--- a/include/ssrc.h
+++ b/include/ssrc.h
@@ -93,6 +93,7 @@ struct ssrc_entry_call {
 	struct ssrc_stats_block *lowest_mos,
 				*highest_mos,
 				average_mos; // contains a running tally of all stats blocks
+	uint16_t no_mos_count; // how many time we where not able to compute MOS due to missing RTT
 	unsigned int last_rtt; // last calculated raw rtt without rtt from opposide side
 
 	// for transcoding


### PR DESCRIPTION
I noticed that mos average also needs to be fixed when missing one leg RTT, here is one example with the problem.

```
[core] --- SSRC 40658ef2
[core] ------ Average MOS 3.2, lowest MOS 0.0 (at 0:04), highest MOS 4.3 (at 0:08)
[core] --- SSRC 57f548f4
[core] ------ Average MOS 4.3, lowest MOS 4.3 (at 0:05), highest MOS 4.3 (at 0:05)
````

with this fix 

```
[core] Calculated MOS from RR for 40671f96 is 0.0
```
and then end of call is accurate
```
--- SSRC 40671f96
------ Average MOS 4.3, lowest MOS 4.3 (at 0:08), highest MOS 4.3 (at 0:08)
--- SSRC 622e6eb
------ Average MOS 4.3, lowest MOS 4.3 (at 0:05), highest MOS 4.3 (at 0:05)
```

```