### PR TITLE
fix rtt from rtcp_rx

### DIFF
--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -356,10 +356,14 @@ void ssrc_receiver_report(struct call_media *m, const struct ssrc_receiver_repor
 
 	ilog(LOG_DEBUG, "Adding opposide side RTT of %u us", other_e->last_rtt);
 
+	long long rtt_end2end = other_e->last_rtt ? (rtt + other_e->last_rtt) : 0;
+	if (other_e->last_rtt_xr > 0) { // use the RTT from RTCP-XR (in ms)
+		rtt_end2end = other_e->last_rtt_xr*1000;
+	}
 	struct ssrc_stats_block *ssb = g_slice_alloc(sizeof(*ssb));
 	*ssb = (struct ssrc_stats_block) {
 		.jitter = jitter,
-		.rtt = other_e->last_rtt ? (rtt + other_e->last_rtt) : 0,
+		.rtt = rtt_end2end,
 		.rtt_leg = rtt,
 		.reported = *tv,
 		.packetloss = (unsigned int) rr->fraction_lost * 100 / 256,
@@ -456,7 +460,7 @@ void ssrc_voip_metrics(struct call_media *m, const struct ssrc_xr_voip_metrics *
 	struct ssrc_entry_call *e = get_ssrc(vm->ssrc, c->ssrc_hash);
 	if (!e)
 		return;
-	e->last_rtt = vm->rnd_trip_delay;
+	e->last_rtt_xr = vm->rnd_trip_delay;
 	obj_put(&e->h);
 }
 

--- a/include/ssrc.h
+++ b/include/ssrc.h
@@ -95,6 +95,7 @@ struct ssrc_entry_call {
 				average_mos; // contains a running tally of all stats blocks
 	uint16_t no_mos_count; // how many time we where not able to compute MOS due to missing RTT
 	unsigned int last_rtt; // last calculated raw rtt without rtt from opposide side
+	unsigned int last_rtt_xr; // last rtt for both legs retreived from RTCP-XR BT-7
 
 	// for transcoding
 	// input only


### PR DESCRIPTION
I found out we where using the RTT from RTCP_XR (both legs in ms)
to represent 1 leg RTT us.