### PR TITLE
Avoid deadlock of notification thread

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -378,7 +378,12 @@ void on_redis_notification(redisAsyncContext *actx, void *reply, void *privdata)
 				goto err;
 			}
 		}
+	        mutex_unlock(&r->lock);
+
+		// unlock before restoring calls to avoid deadlock in case err happens
 		json_restore_call(r, &callid, 1);
+
+	        mutex_lock(&r->lock);
 	}
 
 	if (strncmp(rr->element[3]->str,"del",3)==0) {


### PR DESCRIPTION
Fixes issue #1258.

Testing the other two commits on this branch (rfuchs/1257) also look good for us, so they can be put on master, with this commit included.