### PR TITLE
Feature/recording output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1753,7 +1753,7 @@ call legs, therefore all keys other than `call-id` are currently ignored.
 If the chosen recording method doesn't support in-kernel packet forwarding, enabling call recording
 via this messages will force packet forwarding to happen in userspace only.
 
-If the optional 'output-file' key is set, then its value will be used
+If the optional 'output-destination' key is set, then its value will be used
 as an output file. Note that a filename extension will not be added.
 
 `stop recording` Message

--- a/README.md
+++ b/README.md
@@ -1753,7 +1753,7 @@ call legs, therefore all keys other than `call-id` are currently ignored.
 If the chosen recording method doesn't support in-kernel packet forwarding, enabling call recording
 via this messages will force packet forwarding to happen in userspace only.
 
-If the metadata contains the 'output-file' key, then its value will be used
+If the optional 'output-file' key is set, then its value will be used
 as an output file. Note that a filename extension will not be added.
 
 `stop recording` Message

--- a/README.md
+++ b/README.md
@@ -1753,6 +1753,9 @@ call legs, therefore all keys other than `call-id` are currently ignored.
 If the chosen recording method doesn't support in-kernel packet forwarding, enabling call recording
 via this messages will force packet forwarding to happen in userspace only.
 
+If the metadata contains the 'output-file' key, then its value will be used
+as an output file. Note that a filename extension will not be added.
+
 `stop recording` Message
 -------------------------
 

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1445,7 +1445,7 @@ static const char *call_offer_answer_ng(struct ng_buffer *ngbuf, bencode_item_t 
 	detect_setup_recording(call, &flags.record_call_str, &flags.metadata);
 	if (flags.record_call) {
 		call->recording_on = 1;
-		recording_start(call, NULL, &flags.metadata);
+		recording_start(call, NULL, &flags.metadata, NULL);
 	}
 
 	if (flags.drop_traffic_start) {
@@ -1914,16 +1914,18 @@ const char *call_start_recording_ng(bencode_item_t *input, bencode_item_t *outpu
 	str callid;
 	struct call *call;
 	str metadata;
+	str output_dest;
 
 	if (!bencode_dictionary_get_str(input, "call-id", &callid))
 		return "No call-id in message";
 	bencode_dictionary_get_str(input, "metadata", &metadata);
+	bencode_dictionary_get_str(input, "output_destination", &output_dest);
 	call = call_get_opmode(&callid, OP_OTHER);
 	if (!call)
 		return "Unknown call-id";
 
 	call->recording_on = 1;
-	recording_start(call, NULL, &metadata);
+	recording_start(call, NULL, &metadata, &output_dest);
 
 	rwlock_unlock_w(&call->master_lock);
 	obj_put(call);
@@ -2034,7 +2036,7 @@ const char *call_start_forwarding_ng(bencode_item_t *input, bencode_item_t *outp
 		call->rec_forwarding = 1;
 	}
 
-	recording_start(call, NULL, &flags.metadata);
+	recording_start(call, NULL, &flags.metadata, NULL);
 	errstr = NULL;
 out:
 	if (call) {

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1919,7 +1919,7 @@ const char *call_start_recording_ng(bencode_item_t *input, bencode_item_t *outpu
 	if (!bencode_dictionary_get_str(input, "call-id", &callid))
 		return "No call-id in message";
 	bencode_dictionary_get_str(input, "metadata", &metadata);
-	bencode_dictionary_get_str(input, "output_destination", &output_dest);
+	bencode_dictionary_get_str(input, "output-destination", &output_dest);
 	call = call_get_opmode(&callid, OP_OTHER);
 	if (!call)
 		return "Unknown call-id";

--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -244,6 +244,12 @@ static void update_metadata(struct call *call, str *metadata) {
 	}
 }
 
+static void update_output_dest(struct call *call, str *output_dest) {
+	if (!output_dest || !output_dest->s || !call->recording)
+		return;
+	recording_meta_chunk(call->recording, "OUTPUT_DESTINATION", output_dest);
+}
+
 // lock must be held
 static void update_flags_proc(struct call *call) {
 	append_meta_chunk_null(call->recording, "RECORDING %u", call->recording_on ? 1 : 0);
@@ -259,8 +265,10 @@ static void recording_update_flags(struct call *call) {
 }
 
 // lock must be held
-void recording_start(struct call *call, const char *prefix, str *metadata) {
+void recording_start(struct call *call, const char *prefix, str *metadata, str *output_dest) {
 	update_metadata(call, metadata);
+
+	update_output_dest(call, output_dest);
 
 	if (call->recording) {
 		// already active
@@ -350,7 +358,7 @@ void detect_setup_recording(struct call *call, const str *recordcall, str *metad
 
 	if (!str_cmp(recordcall, "yes") || !str_cmp(recordcall, "on")) {
 		call->recording_on = 1;
-		recording_start(call, NULL, NULL);
+		recording_start(call, NULL, NULL, NULL);
 	}
 	else if (!str_cmp(recordcall, "no") || !str_cmp(recordcall, "off")) {
 		call->recording_on = 0;

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -1923,7 +1923,7 @@ static void json_restore_call(struct redis *r, const str *callid, int foreign) {
 	if (!redis_hash_get_str(&s, &call, "recording_meta_prefix")) {
 		// coverity[check_return : FALSE]
 		redis_hash_get_str(&meta, &call, "recording_metadata");
-		recording_start(c, s.s, &meta);
+		recording_start(c, s.s, &meta, NULL);
 	}
 
 	err = NULL;

--- a/include/recording.h
+++ b/include/recording.h
@@ -117,7 +117,7 @@ void recording_fs_free(void);
  */
 void detect_setup_recording(struct call *call, const str *recordcall, str *metadata);
 
-void recording_start(struct call *call, const char *prefix, str *metadata);
+void recording_start(struct call *call, const char *prefix, str *metadata, str *output_dest);
 void recording_stop(struct call *call, str *metadata);
 
 

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -150,6 +150,7 @@ static void meta_ptime(metafile_t *mf, unsigned long mnum, int ptime)
 }
 
 static char *get_output_path(metafile_t *mf) {
+	static const char *of = "output-file";
 	char *res = NULL;
 	str all_meta;
 	str_init(&all_meta, mf->metadata);
@@ -162,8 +163,8 @@ static char *get_output_path(metafile_t *mf) {
 			// key:value separator not found, skip
 			continue;
 		}
-		if (strncmp(key.s, "output-dir", 10) >= 0) {
-			ilog(LOG_INFO, "Metadata output-dir found token=%s", token.s);
+		if (strncmp(key.s, of, strlen(of)) >= 0) {
+			ilog(LOG_INFO, "Metadata output-file found token=%s", token.s);
 			res = token.s;
 			break;
 		}

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -175,7 +175,7 @@ done:;
 	output_t *ret = output_alloc(path, f->str);
 	create_parent_dirs(ret->full_filename);
 
-	g_string_free(f, FALSE);
+	g_string_free(f, TRUE);
 
 	return ret;
 }

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -238,7 +238,12 @@ int output_config(output_t *output, const format_t *requested_format, format_t *
 	char *full_fn = NULL;
 	char suff[16] = "";
 	for (int i = 1; i < 20; i++) {
-		full_fn = g_strdup_printf("%s%s.%s", output->full_filename, suff, output->file_format);
+		if (!output->skip_filename_extension) {
+			full_fn = g_strdup_printf("%s%s.%s", output->full_filename, suff, output->file_format);
+		}
+		else {
+			full_fn = g_strdup_printf("%s%s", output->full_filename, suff);
+		}
 		if (!g_file_test(full_fn, G_FILE_TEST_EXISTS))
 			goto got_fn;
 		ilog(LOG_INFO, "Storing record in %s", full_fn);

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -241,6 +241,7 @@ int output_config(output_t *output, const format_t *requested_format, format_t *
 		full_fn = g_strdup_printf("%s%s.%s", output->full_filename, suff, output->file_format);
 		if (!g_file_test(full_fn, G_FILE_TEST_EXISTS))
 			goto got_fn;
+		ilog(LOG_INFO, "Storing record in %s", full_fn);
 		snprintf(suff, sizeof(suff), "-%i", i);
 		g_free(full_fn);
 	}

--- a/recording-daemon/output.h
+++ b/recording-daemon/output.h
@@ -11,6 +11,7 @@ extern int mp3_bitrate;
 void output_init(const char *format);
 
 output_t *output_new(const char *path, const char *call, const char *type);
+output_t *output_new_from_full_path(const char *path, char *name);
 void output_close(output_t *);
 
 int output_config(output_t *output, const format_t *requested_format, format_t *actual_format);

--- a/recording-daemon/packet.c
+++ b/recording-daemon/packet.c
@@ -152,7 +152,6 @@ void ssrc_free(void *p) {
 	g_slice_free1(sizeof(*s), s);
 }
 
-
 // mf must be unlocked; returns ssrc locked
 static ssrc_t *ssrc_get(stream_t *stream, unsigned long ssrc) {
 	metafile_t *mf = stream->metafile;
@@ -177,9 +176,26 @@ out:
 	dbg("Init for SSRC %s%lx%s of stream #%lu", FMT_M(ret->ssrc), stream->id);
 
 	if (mf->recording_on && !ret->output && output_single) {
-		char buf[16];
-		snprintf(buf, sizeof(buf), "%08lx", ssrc);
-		ret->output = output_new(output_dir, mf->parent, buf);
+		ilog(LOG_INFO, "Metadata %s and output %s", mf->metadata, mf->output_dest);
+		if (mf->output_dest) {
+			char path[256];
+			strncpy(path, mf->output_dest, sizeof(path));
+			char *sep = strrchr(path, '/');
+			if (sep) {
+				char *filename = sep + 1;
+				*sep = 0;
+				ret->output = output_new(path, mf->parent, filename);
+				ret->output->skip_filename_extension = TRUE;
+			}
+			else {
+				ret->output = output_new(output_dir, mf->parent, path);
+			}
+		}
+		else {
+			char buf[16];
+			snprintf(buf, sizeof(buf), "%08lx", ssrc);
+			ret->output = output_new(output_dir, mf->parent, buf);
+		}
 		db_do_stream(mf, ret->output, "single", stream, ssrc);
 	}
 	if ((stream->forwarding_on || mf->forwarding_on) && !ret->tls_fwd_stream) {

--- a/recording-daemon/packet.c
+++ b/recording-daemon/packet.c
@@ -176,7 +176,7 @@ out:
 	dbg("Init for SSRC %s%lx%s of stream #%lu", FMT_M(ret->ssrc), stream->id);
 
 	if (mf->recording_on && !ret->output && output_single) {
-		ilog(LOG_INFO, "Metadata %s and output %s", mf->metadata, mf->output_dest);
+		dbg("Metadata %s, output destination %s", mf->metadata, mf->output_dest);
 		if (mf->output_dest) {
 			char path[256];
 			strncpy(path, mf->output_dest, sizeof(path));
@@ -184,11 +184,11 @@ out:
 			if (sep) {
 				char *filename = sep + 1;
 				*sep = 0;
-				ret->output = output_new(path, mf->parent, filename);
+				ret->output = output_new_from_full_path(path, filename);
 				ret->output->skip_filename_extension = TRUE;
 			}
 			else {
-				ret->output = output_new(output_dir, mf->parent, path);
+				ret->output = output_new_from_full_path(output_dir, path);
 			}
 		}
 		else {

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -111,6 +111,7 @@ struct metafile_s {
 	char *call_id;
 	char *metadata;
 	char *metadata_db;
+	char *output_dest;
 	off_t pos;
 	unsigned long long db_id;
 
@@ -146,6 +147,7 @@ struct output_s {
 		*filename; // path + filename + suffix
 	const char *file_format;
 	unsigned long long db_id;
+	gboolean skip_filename_extension;
 	unsigned int channel_mult;
 
 	AVFormatContext *fmtctx;


### PR DESCRIPTION
This ads functionality to set output dir / filename per recording. We use this internally to save recording files directly to S3 fs without exposing the file extension.