### PR TITLE
Fix G729 packet duration

### DIFF
--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -2219,6 +2219,7 @@ static int bcg729_encoder_input(encoder_t *enc, AVFrame **frame) {
 
 	enc->avpkt.size = len;
 	enc->avpkt.pts = (*frame)->pts;
+	enc->avpkt.duration = len * 8; // Duration is used by encoder_input_data for pts calculation
 
 	return 0;
 }


### PR DESCRIPTION
Without this correction, timestamp is not incremented in case of transcoding