### PR TITLE
Fix G729 packet duration

### DIFF
--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -2467,6 +2467,7 @@ static int bcg729_encoder_input(encoder_t *enc, AVFrame **frame) {
 
 	enc->avpkt->size = len;
 	enc->avpkt->pts = (*frame)->pts;
+	enc->avpkt->duration = len * 8; // Duration is used by encoder_input_data for pts calculation
 
 	return 0;
 }


### PR DESCRIPTION
Without this correction, timestamp is not incremented in case of transcoding.

As mentioned in encoder_input_data rtpengine don't rely on encoder pts, but calculating pts from packet duration.
As G729 is not encoded by avcodec we must set the packet duration manually.