### PR TITLE
not report errors if "which" is failing.

### DIFF
--- a/debian/ngcp-rtpengine-iptables-setup
+++ b/debian/ngcp-rtpengine-iptables-setup
@@ -31,7 +31,7 @@ fi
 
 ###
 
-if [ -x "$(which ngcp-virt-identify)" ]; then
+if [ -x "$(which ngcp-virt-identify 2>/dev/null)" ]; then
   if ngcp-virt-identify --type container; then
     VIRT="yes"
   fi


### PR DESCRIPTION
Since ngcp-virt-identify is not part of rtpengine #916 the helper Pre/Post script should not report errors if "which" is failing.