### PR TITLE
Add ngcp-rtpengine-iptables-setup to EL based systems

### DIFF
--- a/el/ngcp-rtpengine-iptables-setup
+++ b/el/ngcp-rtpengine-iptables-setup
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+TABLE=0
+MODNAME=xt_RTPENGINE
+MANAGE_IPTABLES=yes
+
+DEFAULTS=/etc/sysconfig/rtpengine
+
+# Load startup options if available
+if [ -f "$DEFAULTS" ]; then
+  . "$DEFAULTS" || true
+fi
+
+MODPROBE_OPTIONS=""
+
+# Handle requested setuid/setgid.
+if ! test -z "$SET_USER"; then
+  PUID=$(id -u "$SET_USER" 2> /dev/null)
+  test -z "$PUID" || MODPROBE_OPTIONS="$MODPROBE_OPTIONS proc_uid=$PUID"
+  if test -z "$SET_GROUP"; then
+    PGID=$(id -g "$SET_USER" 2> /dev/null)
+    test -z "$PGID" || MODPROBE_OPTIONS="$MODPROBE_OPTIONS proc_gid=$PGID"
+  fi
+fi
+
+if ! test -z "$SET_GROUP"; then
+  PGID=$(grep "^$SET_GROUP:" /etc/group | cut -d: -f3 2> /dev/null)
+  test -z "$PGID" || MODPROBE_OPTIONS="$MODPROBE_OPTIONS proc_gid=$PGID"
+fi
+
+###
+
+if [ -x "$(which ngcp-virt-identify)" ]; then
+  if ngcp-virt-identify --type container; then
+    VIRT="yes"
+  fi
+fi
+
+firewall_setup()
+{
+  if [ "$TABLE" -lt 0 ] || [ "$VIRT" = "yes" ]; then
+    return
+  fi
+
+  if [ "$MANAGE_IPTABLES" != "yes" ]; then
+    return
+  fi
+
+  # shellcheck disable=SC2086
+  modprobe $MODNAME $MODPROBE_OPTIONS
+
+  iptables -N rtpengine 2>/dev/null
+  iptables -D INPUT -j rtpengine 2>/dev/null
+  iptables -D INPUT -p udp -j rtpengine 2>/dev/null
+  iptables -I INPUT -p udp -j rtpengine
+  iptables -D rtpengine -p udp -j RTPENGINE --id "$TABLE" 2>/dev/null
+  iptables -I rtpengine -p udp -j RTPENGINE --id "$TABLE"
+  ip6tables -N rtpengine 2>/dev/null
+  ip6tables -D INPUT -j rtpengine 2>/dev/null
+  ip6tables -D INPUT -p udp -j rtpengine 2>/dev/null
+  ip6tables -I INPUT -p udp -j rtpengine
+  ip6tables -D rtpengine -p udp -j RTPENGINE --id "$TABLE" 2>/dev/null
+  ip6tables -I rtpengine -p udp -j RTPENGINE --id "$TABLE"
+}
+
+firewall_teardown()
+{
+  if [ "$TABLE" -lt 0 ] || [ "$VIRT" = "yes" ]; then
+    return
+  fi
+
+  # XXX: Wait a bit to make sure the daemon has been stopped.
+  sleep 1
+
+  if [ -e /proc/rtpengine/control ]; then
+    echo "del $TABLE" >/proc/rtpengine/control 2>/dev/null
+  fi
+
+  if [ "$MANAGE_IPTABLES" != "yes" ]; then
+    return
+  fi
+
+  iptables -D rtpengine -p udp -j RTPENGINE --id "$TABLE" 2>/dev/null
+  ip6tables -D rtpengine -p udp -j RTPENGINE --id "$TABLE" 2>/dev/null
+}
+
+case "$1" in
+  start)
+    firewall_setup
+    ;;
+  stop)
+    firewall_teardown
+    ;;
+  *)
+    echo "Usage: $0 {start|stop}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/el/ngcp-rtpengine-iptables-setup
+++ b/el/ngcp-rtpengine-iptables-setup
@@ -31,7 +31,7 @@ fi
 
 ###
 
-if [ -x "$(which ngcp-virt-identify)" ]; then
+if [ -x "$(which ngcp-virt-identify 2>/dev/null)" ]; then
   if ngcp-virt-identify --type container; then
     VIRT="yes"
   fi

--- a/el/rtpengine.service
+++ b/el/rtpengine.service
@@ -1,17 +1,17 @@
 [Unit]
-Description=NGCP RtpEngine - RTP Media Proxy
-Wants=network-online.target
+Description=NGCP RTP/media Proxy Daemon
 After=network-online.target
+After=remote-fs.target
+Requires=network-online.target
 
 [Service]
-Type=forking
-User=ngcp-rtpengine
-Group=daemon
-Environment=CFGFILE=/etc/rtpengine/rtpengine.conf
+Type=notify
 EnvironmentFile=/etc/sysconfig/rtpengine
+Environment=CFGFILE=/etc/rtpengine/rtpengine.conf
 PIDFile=/run/rtpengine.pid
-ExecStart=/usr/sbin/rtpengine --config-file=${CFGFILE} --interface=${INTERFACE} --listen-ng=${LISTEN_UDP} --log-facility=${LOG_FACILITY} --log-level=${LOG_LEVEL}
-Restart=on-failure
+ExecStartPre=/usr/sbin/ngcp-rtpengine-iptables-setup start
+ExecStart=/usr/sbin/rtpengine -f -E --no-log-timestamps --pidfile $PIDFile --config-file $CFGFILE --table $TABLE
+ExecStopPost=/usr/sbin/ngcp-rtpengine-iptables-setup stop
 
 [Install]
 WantedBy=multi-user.target

--- a/el/rtpengine.service
+++ b/el/rtpengine.service
@@ -1,13 +1,9 @@
 [Unit]
 Description=NGCP RTP/media Proxy Daemon
 After=network-online.target
-Requires=network-online.target
 
 [Service]
 Type=forking
-User=ngcp-rtpengine
-Group=daemon
-Environment=CFGFILE=/etc/rtpengine/rtpengine-recording.conf
 EnvironmentFile=/etc/sysconfig/rtpengine
 Environment=CFGFILE=/etc/rtpengine/rtpengine.conf
 PIDFile=/run/rtpengine.pid

--- a/el/rtpengine.service
+++ b/el/rtpengine.service
@@ -1,16 +1,18 @@
 [Unit]
 Description=NGCP RTP/media Proxy Daemon
 After=network-online.target
-After=remote-fs.target
 Requires=network-online.target
 
 [Service]
-Type=notify
+Type=forking
+User=ngcp-rtpengine
+Group=daemon
+Environment=CFGFILE=/etc/rtpengine/rtpengine-recording.conf
 EnvironmentFile=/etc/sysconfig/rtpengine
 Environment=CFGFILE=/etc/rtpengine/rtpengine.conf
 PIDFile=/run/rtpengine.pid
 ExecStartPre=/usr/sbin/ngcp-rtpengine-iptables-setup start
-ExecStart=/usr/sbin/rtpengine -f -E --no-log-timestamps --pidfile $PIDFile --config-file $CFGFILE --table $TABLE
+ExecStart=/usr/sbin/rtpengine --no-log-timestamps --pidfile=${PIDFile} --config-file=${CFGFILE} --table=${TABLE}
 ExecStopPost=/usr/sbin/ngcp-rtpengine-iptables-setup stop
 
 [Install]

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -124,6 +124,8 @@ install -D -p -m755 recording-daemon/%{binname}-recording %{buildroot}%{_sbindir
 %if 0%{?has_systemd_dirs}
 install -D -p -m644 el/%{binname}.service \
 	%{buildroot}%{_unitdir}/%{binname}.service
+install -D -p -m755 el/ngcp-rtpengine-iptables-setup \
+	%{buildroot}%{_sbindir}/ngcp-rtpengine-iptables-setup
 %else
 install -D -p -m755 el/%{binname}.init \
 	%{buildroot}%{_initrddir}/%{name}

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -239,6 +239,8 @@ true
 # init.d script and configuration file
 %if 0%{?has_systemd_dirs}
 %{_unitdir}/%{binname}.service
+# Systemd iptables setup
+%{_sbindir}/ngcp-rtpengine-iptables-setup
 %else
 %{_initrddir}/%{name}
 %endif


### PR DESCRIPTION
The el-sysv init scripts includes also an iptables wrapper. 
I use the debian ngcp-rtpengine-iptables-setup and add it to the spec file and the service file.