### PR TITLE
show codec name in media stats

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1669,7 +1669,7 @@ static void ng_stats_media(bencode_item_t *list, const struct call_media *m,
 	if (m->protocol)
 		bencode_dictionary_add_string(dict, "protocol", m->protocol->name);
 	if (rtp_pt)
-		bencode_dictionary_add_str(dict, "codec", &rtp_pt->encoding_with_params);
+		bencode_dictionary_add_str_dup(dict, "codec", &rtp_pt->encoding_with_params);
 
 	streams = bencode_dictionary_add_list(dict, "streams");
 

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1655,9 +1655,12 @@ static void ng_stats_media(bencode_item_t *list, const struct call_media *m,
 	bencode_item_t *dict, *streams = NULL, *flags;
 	GList *l;
 	struct packet_stream *ps;
+	const struct rtp_payload_type *rtp_pt = NULL;
 
 	if (!list)
 		goto stats;
+
+	rtp_pt = __rtp_stats_codec((struct call_media *)m);
 
 	dict = bencode_list_add_dictionary(list);
 
@@ -1665,6 +1668,8 @@ static void ng_stats_media(bencode_item_t *list, const struct call_media *m,
 	bencode_dictionary_add_str(dict, "type", &m->type);
 	if (m->protocol)
 		bencode_dictionary_add_string(dict, "protocol", m->protocol->name);
+	if (rtp_pt)
+		bencode_dictionary_add_str(dict, "codec", &rtp_pt->encoding_with_params);
 
 	streams = bencode_dictionary_add_list(dict, "streams");
 


### PR DESCRIPTION
Adds codec name in media stats output

              ...
              "0f0d2e18": {
                  "in dialogue with": "cs6kn1rloc",
                  "tag": "0f0d2e18",
                  "codec": "PCMA/8000",
                  "medias": [
                    {
                      "protocol": "RTP/SAVPF",
                      "index": 1,
                      "type": "audio",
                      "streams": [
                         {
                           "endpoint": {
               ...