### PR TITLE
Add support for time64 libcs

### DIFF
--- a/daemon/cdr.c
+++ b/daemon/cdr.c
@@ -69,9 +69,9 @@ void cdr_update_entry(struct call* c) {
 
 		if (_log_facility_cdr) {
 			g_string_append_printf(cdr,
-				"ml%i_start_time=%ld.%06lu, "
-				"ml%i_end_time=%ld.%06ld, "
-				"ml%i_duration=%ld.%06ld, "
+				"ml%i_start_time=%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT ", "
+				"ml%i_end_time=%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT ", "
+				"ml%i_duration=%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT ", "
 				"ml%i_termination=%s, "
 				"ml%i_local_tag=%s, "
 				"ml%i_local_tag_type=%s, ",

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -574,7 +574,7 @@ static void cli_incoming_list_callid(str *instr, struct cli_writer *cw) {
 		cw->cw_printf(cw, "--- Tag '" STR_FORMAT "', type: %s, label '" STR_FORMAT "', "
 				"branch '" STR_FORMAT "', "
 				"callduration "
-				"%ld.%06ld\n",
+				"%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT "\n",
 			STR_FMT(&ml->tag), get_tag_type_text(ml->tagtype),
 			STR_FMT(ml->label.s ? &ml->label : &STR_EMPTY),
 			STR_FMT(&ml->viabranch),

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -884,7 +884,7 @@ static int redis_check_conn(struct redis *r) {
 	gettimeofday(&rtpe_now, NULL);
 
 	if ((r->state == REDIS_STATE_DISCONNECTED) && (r->restore_tick > rtpe_now.tv_sec)) {
-		ilog(LOG_WARNING, "Redis server %s is disabled. Don't try RE-Establishing for %ld more seconds",
+		ilog(LOG_WARNING, "Redis server %s is disabled. Don't try RE-Establishing for %" TIME_T_INT_FMT " more seconds",
 				endpoint_print_buf(&r->endpoint),r->restore_tick - rtpe_now.tv_sec);
 		return REDIS_STATE_DISCONNECTED;
 	}

--- a/daemon/statistics.c
+++ b/daemon/statistics.c
@@ -461,7 +461,7 @@ GQueue *statistics_gather_metrics(void) {
 	PROM("zero_packet_streams_total", "counter");
 	METRIC("onewaystreams", "Total number of 1-way streams", UINT64F, UINT64F,atomic64_get(&rtpe_stats_cumulative.oneway_stream_sess));
 	PROM("one_way_sessions_total", "counter");
-	METRICva("avgcallduration", "Average call duration", "%ld.%06ld", "%ld.%06ld", avg.tv_sec, avg.tv_usec);
+	METRICva("avgcallduration", "Average call duration", "%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT, "%" TIME_T_INT_FMT ".%06" TIME_T_INT_FMT, avg.tv_sec, avg.tv_usec);
 
 	calls_dur_iv = (double) atomic64_get_na(&rtpe_stats_graphite_interval.total_calls_duration) / 1000000.0;
 	min_sess_iv = atomic64_get(&rtpe_stats_gauge_graphite_min_max_interval.min.total_sessions);

--- a/lib/loglib.h
+++ b/lib/loglib.h
@@ -2,12 +2,20 @@
 #define _LOGLIB_H_
 
 
+#include <sys/time.h> /* __USE_TIME_BITS64 */
 #include <glib.h>
 #include <syslog.h>
 #include <stdarg.h>
 #include "compat.h"
 #include "auxlib.h"
 
+#ifndef TIME_T_INT_FMT
+#ifdef __USE_TIME_BITS64
+#define TIME_T_INT_FMT PRId64
+#else
+#define TIME_T_INT_FMT "ld"
+#endif
+#endif
 
 extern int ilog_facility;
 


### PR DESCRIPTION
libcs are implementing changes to fix the year 2038 issue on 32 bit
platforms (see [1]). musl libc already went ahead and implemented it,
starting with musl-1.2.0 (see [2]).

This commit adds two new definitions to lib/loglib.h:

TIME_T_INT_FMT
TIME_T_UINT_FMT

If __USE_TIME_BITS64 is defined (by a time64 libc, see [1]), they're set
to the proper conversions for type int64_t, PRId64 and PRIu64
respectively. If __USE_TIME_BITS64 is not defined, the status quo
remains unchanged ("%ld" and "%lu" are used).

The new definitions are used in the different parts of rtpengine, where
appropriate.

These changes get rid of the new warnings that appeared with musl-1.2.0.
Below an example warning:

In file included from ./log.h:6,
                 from ../include/obj.h:94,
                 from ../include/media_socket.h:9,
                 from ../include/call.h:26,
                 from ../include/redis.h:15,
                 from redis.c:1:
redis.c: In function 'redis_check_conn':
../lib/loglib.h:56:30: warning: format '%ld' expects argument of type 'long int', but argument 5 has type 'time_t' {aka 'long long int'} [-Wformat=]
   56 |                 __ilog(prio, "[%s] " fmt, log_level_names[system], ##__VA_ARGS__);                                              \
      |                              ^~~~~~~
../lib/loglib.h:64:39: note: in expansion of macro 'ilogsn'
   64 | #define ilogs(system, prio, fmt, ...) ilogsn(log_level_index_ ## system, prio, fmt, ##__VA_ARGS__)
      |                                       ^~~~~~
../lib/loglib.h:63:30: note: in expansion of macro 'ilogs'
   63 | #define ilog(prio, fmt, ...) ilogs(core, prio, fmt, ##__VA_ARGS__)
      |                              ^~~~~
redis.c:887:17: note: in expansion of macro 'ilog'
  887 |                 ilog(LOG_WARNING, "Redis server %s is disabled. Don't try RE-Establishing for %ld more seconds",
      |                 ^~~~

[1] https://sourceware.org/glibc/wiki/Y2038ProofnessDesign
[2] https://musl.libc.org/time64.html

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>