### PR TITLE
Various changes of RTP timeout handling to handle timeouts on single streams

### DIFF
--- a/include/call.h
+++ b/include/call.h
@@ -342,6 +342,8 @@ struct packet_stream {
 
 	/* in_lock must be held for SETTING these: */
 	volatile unsigned int	ps_flags;
+
+	unsigned int		missed_packet_counter;
 };
 
 /* protected by call->master_lock, except the RO elements */
@@ -441,6 +443,7 @@ struct call_monologue {
 	unsigned int		silence_media:1;
 	unsigned int		rec_forwarding:1;
 	unsigned int		inject_dtmf:1;
+	unsigned int		mark_deleted:1;
 };
 
 struct call_iterator_list {
@@ -546,6 +549,9 @@ struct call {
 	unsigned int		foreign_media:1; // for calls taken over, tracks whether we have media
 	unsigned int		disable_jb:1;
 	unsigned int		debug:1;
+
+	int			timeout_mode;
+	time_t			timeout_activated;
 };
 
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -74,6 +74,12 @@ struct sdp_ng_flags {
 		MEO_BKW,
 		MEO_BOTH,
 	} media_echo:3;
+	enum {
+		TIMEOUT_DEFAULT = 0,
+		TIMEOUT_OFF,
+		TIMEOUT_ALL,
+		TIMEOUT_ANY
+	} timeout_mode:2;
 	unsigned int asymmetric:1,
 	             protocol_accept:1,
 	             no_redis_update:1,

--- a/include/main.h
+++ b/include/main.h
@@ -39,6 +39,7 @@ struct rtpengine_config {
 	int			silent_timeout;
 	int			final_timeout;
 	int			offer_timeout;
+	int			timeout_mode;
 	int			delete_delay;
 	GQueue		        redis_subscribed_keyspaces;
 	int			redis_expires_secs;


### PR DESCRIPTION
- introduced timeout-mode parameter to control mode of operation off/any/all during session
  off - don't monitor timeouts / turn monitoring off
  any - react if a timeout occur on any RTP stream
  all - react if timeout occur on all streams (old behavior)
- Don't monitor RTCP streams for timeout (to prevent false alarms if RTP timeout is very low)

This patch introduces primary the possibility to react on RTP timeouts of a single stream.

During call establishment / early-media, there is often only one stream direction active. To prevent false alarms
for this case, the timeout-mode parameter for the call-interface was added. The logic is, that a call starts with
a disabled timeout monitoring and when the session is established in both directions (for example 200OK Reply for
an answer) the timeout will be activated.

When activated, timeout_activated element of struct call will be set to earliest possible timeout occurence
(activation time + timeout time). This should prevent false alarms immediatliy after session establishment

There is still an unresolved problem at the moment. Even timeout_activated is used, it sometimes happens
that on first check a timeout is detected. This occurs even, when timeout value (and timeout_activated
in succession) is increased.
To circumvent this, missed_packet_counter of struct packet_stream is used, so that the checks fails on the third
missed package in a row.

Signed-off-by: Arnd Schmitter <arnd@lgcm.de>