### PR TITLE
Add new graphite-timeout parameter

### DIFF
--- a/daemon/graphite.c
+++ b/daemon/graphite.c
@@ -56,6 +56,11 @@ static int connect_to_graphite_server(const endpoint_t *graphite_ep) {
 	ilog(LOG_INFO, "Connecting to graphite server %s", endpoint_print_buf(graphite_ep));
 
 	rc = connect_socket_nb(&graphite_sock, SOCK_STREAM, graphite_ep);
+
+	if (rtpe_config.graphite_timeout > 0 && !(graphite_sock.fd < 0)) {
+		usertimeout(graphite_sock.fd, rtpe_config.graphite_timeout * 1000);
+	}
+
 	if (rc == -1) {
 		ilog(LOG_ERROR,"Couldn't make socket for connecting to graphite.");
 		return -1;

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -454,6 +454,7 @@ static void options(int *argc, char ***argv) {
 		{ "graphite", 'g', 0, G_OPTION_ARG_STRING,    &graphitep,     "Address of the graphite server",   "IP46|HOSTNAME:PORT"     },
 		{ "graphite-interval",  'G', 0, G_OPTION_ARG_INT,    &rtpe_config.graphite_interval,  "Graphite send interval in seconds",    "INT"   },
 		{ "graphite-prefix",0,  0,	G_OPTION_ARG_STRING, &graphite_prefix_s, "Prefix for graphite line", "STRING"},
+		{ "graphite-timeout", 0, 0, G_OPTION_ARG_INT, &rtpe_config.graphite_timeout, "Graphite socket timeout interval in seconds", "INT" },
 		{ "tos",	'T', 0, G_OPTION_ARG_INT,	&rtpe_config.default_tos,		"Default TOS value to set on streams",	"INT"		},
 		{ "control-tos",0 , 0, G_OPTION_ARG_INT,	&rtpe_config.control_tos,		"Default TOS value to set on control-ng",	"INT"		},
 		{ "timeout",	'o', 0, G_OPTION_ARG_INT,	&rtpe_config.timeout,	"RTP timeout",			"SECS"		},
@@ -875,6 +876,7 @@ void fill_initial_rtpe_cfg(struct rtpengine_config* ini_rtpe_cfg) {
 	ini_rtpe_cfg->default_tos = rtpe_config.default_tos;
 	ini_rtpe_cfg->control_tos = rtpe_config.control_tos;
 	ini_rtpe_cfg->graphite_interval = rtpe_config.graphite_interval;
+	ini_rtpe_cfg->graphite_timeout= rtpe_config.graphite_timeout;
 	ini_rtpe_cfg->redis_num_threads = rtpe_config.redis_num_threads;
 	ini_rtpe_cfg->homer_protocol = rtpe_config.homer_protocol;
 	ini_rtpe_cfg->homer_id = rtpe_config.homer_id;

--- a/daemon/rtpengine.pod
+++ b/daemon/rtpengine.pod
@@ -143,6 +143,11 @@ Interval of the time when information is sent to the graphite server.
 
 Add a prefix for every graphite line.
 
+=item B<--graphite-timeout=>I<INT>
+
+Sets after how much time (seconds) to force fail graphite socket connection,
+when graphite server is filtered out. If set to 0, there are no changes.
+
 =item B<-t>, B<--tos=>I<INT>
 
 Takes an integer as argument and if given, specifies the TOS value that

--- a/include/main.h
+++ b/include/main.h
@@ -49,6 +49,7 @@ struct rtpengine_config {
 	enum log_format		log_format;
 	endpoint_t		graphite_ep;
 	int			graphite_interval;
+	int			graphite_timeout;
 	int			redis_num_threads;
 	GQueue			interfaces;
 	endpoint_t		tcp_listen_ep;

--- a/lib/socket.h
+++ b/lib/socket.h
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <netinet/tcp.h>
 
 
 
@@ -180,6 +181,10 @@ INLINE ssize_t socket_sendiov(socket_t *s, const struct iovec *v, unsigned int l
 
 
 /* XXX obsolete these? */
+INLINE void usertimeout(int fd, unsigned int val) {
+	// coverity[check_return : FALSE]
+	setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &val, sizeof(val));
+}
 INLINE void nonblock(int fd) {
 	// coverity[check_return : FALSE]
 	fcntl(fd, F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
Needed to be able to set graphite socket timeout.
Useful when one wants rtpengine to force the graphite connection
to fail faster, in case graphite server gets filtered while
connection is ongoing.