### PR TITLE
Fix `subscribe request` SDP media direction

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2972,7 +2972,7 @@ static int monologue_subscribe_request1(struct call_monologue *src_ml, struct ca
 
 		codec_handlers_update(dst_media, src_media, flags, sp);
 
-		if (MEDIA_ISSET(src_media, SEND))
+		if (MEDIA_ISSET(src_media, RECV))
 			MEDIA_SET(dst_media, SEND);
 		else
 			MEDIA_CLEAR(dst_media, SEND);

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2972,7 +2972,10 @@ static int monologue_subscribe_request1(struct call_monologue *src_ml, struct ca
 
 		codec_handlers_update(dst_media, src_media, flags, sp);
 
-		MEDIA_SET(dst_media, SEND);
+		if (MEDIA_ISSET(src_media, SEND))
+			MEDIA_SET(dst_media, SEND);
+		else
+			MEDIA_CLEAR(dst_media, SEND);
 		MEDIA_CLEAR(dst_media, RECV);
 
 		__rtcp_mux_set(flags, dst_media);


### PR DESCRIPTION
When building the SDP for a `subscribe request` command, take into
consideration the media direction of the source stream - if stream is
`recvonly`, then we do not have anything to send, thus the direction
should be advertised as `inactive`, rather than `sendonly`.