### PR TITLE
provide sendrecv mode in siprec tag-medias and media-labels

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -3032,6 +3032,7 @@ const char *call_subscribe_request_ng(bencode_item_t *input, bencode_item_t *out
 				bencode_dictionary_add_integer(med_ent, "index", media->index);
 				bencode_dictionary_add_str(med_ent, "type", &media->type);
 				bencode_dictionary_add_str(med_ent, "label", &media->label);
+				bencode_dictionary_add_string(med_ent, "mode", sdp_get_sendrecv(media));
 
 				if (media_labels) {
 					bencode_item_t *label =
@@ -3041,6 +3042,7 @@ const char *call_subscribe_request_ng(bencode_item_t *input, bencode_item_t *out
 					bencode_dictionary_add_str(label, "type", &media->type);
 					if (source_ml->label.len)
 						bencode_dictionary_add_str(label, "label", &source_ml->label);
+					bencode_dictionary_add_string(label, "mode", sdp_get_sendrecv(media));
 				}
 			}
 		}

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -2514,16 +2514,21 @@ dup:
 	monologue->last_out_sdp = g_string_new_len(chop->output->str, chop->output->len);
 }
 
+const char *sdp_get_sendrecv(struct call_media *media) {
+	if (MEDIA_ARESET2(media, SEND, RECV))
+		return "sendrecv";
+	else if (MEDIA_ISSET(media, SEND))
+		return "sendonly";
+	else if (MEDIA_ISSET(media, RECV))
+		return "recvonly";
+	else
+		return "inactive";
+}
 
 void print_sendrecv(GString *s, struct call_media *media) {
-	if (MEDIA_ARESET2(media, SEND, RECV))
-		g_string_append(s, "a=sendrecv\r\n");
-	else if (MEDIA_ISSET(media, SEND))
-		g_string_append(s, "a=sendonly\r\n");
-	else if (MEDIA_ISSET(media, RECV))
-		g_string_append(s, "a=recvonly\r\n");
-	else
-		g_string_append(s, "a=inactive\r\n");
+	g_string_append(s, "a=");
+	g_string_append(s, sdp_get_sendrecv(media));
+	g_string_append(s, "\r\n");
 }
 
 

--- a/include/sdp.h
+++ b/include/sdp.h
@@ -27,6 +27,7 @@ void sdp_free(GQueue *sessions);
 int sdp_replace(struct sdp_chopper *, GQueue *, struct call_monologue *, struct sdp_ng_flags *);
 int sdp_is_duplicate(GQueue *sessions);
 int sdp_create(str *out, struct call_monologue *, struct sdp_ng_flags *flags);
+const char *sdp_get_sendrecv(struct call_media *media);
 
 int sdp_parse_candidate(struct ice_candidate *cand, const str *s); // returns -1, 0, 1
 


### PR DESCRIPTION
SIPREC protocol requires to know whether a media stream is actively sending media or not.