### PR TITLE
fix compilation with iptables 1.8.8

### DIFF
--- a/iptables-extension/libxt_RTPENGINE.c
+++ b/iptables-extension/libxt_RTPENGINE.c
@@ -5,6 +5,10 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#ifndef _init
+#define _init __attribute__((constructor)) _INIT
+#endif
+
 #if defined(__ipt)
 #include <iptables.h>
 #elif defined(__ip6t)


### PR DESCRIPTION
The extension handling changed [0,1]. Fix compilation with iptables
1.8.8 [2].

[0] - https://git.netfilter.org/iptables/commit/?id=ef108943f69a6e20533d58823740d3f0534ea8ec
[1] - https://git.netfilter.org/iptables/commit/?id=6c689b639cf8e2aeced8685eca2915892d76ad86
[2] - openwrt/openwrt#9886
