### PR TITLE
make the build reproducible

### DIFF
--- a/lib/lib.Makefile
+++ b/lib/lib.Makefile
@@ -9,7 +9,7 @@ HAVE_DPKG_PARSECHANGELOG?=$(shell which dpkg-parsechangelog 2>/dev/null)
 
 ifeq ($(RELEASE_DATE),)
   ifneq ($(HAVE_DPKG_PARSECHANGELOG),)
-    RELEASE_DATE=$(shell date -d "@$$(dpkg-parsechangelog -l$(RTPENGINE_ROOT_DIR)/debian/changelog -STimestamp)" '+%F')
+    RELEASE_DATE=$(shell date -u -d "@$$(dpkg-parsechangelog -l$(RTPENGINE_ROOT_DIR)/debian/changelog -STimestamp)" '+%F')
   endif
   ifeq ($(RELEASE_DATE),)
     RELEASE_DATE=undefined


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1012766

> Whilst working on the Reproducible Builds effort [0] we noticed that
> rtpengine could not be built reproducibly.
>
> Whilst it did use the value from debian/changelog, the RELEASE_DATE
> variable changed due to underlying system timezone setting. A patch
> is attached that passes -u/--utc to the call to date(1).
>
> [0] https://reproducible-builds.org/