### PR TITLE
TT#14008 DTX buffer PT change: take supp PTs into account

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2983,10 +2983,33 @@ static void __dtx_send_later(struct codec_timer *ct) {
 			shutdown = true;
 		else if (dtxb->ct.next.tv_sec == 0)
 			shutdown = true;
-		else if (ps->ssrc_in[0]->tracker.most_len < 1)
-			shutdown = true;
-		else if (ps->ssrc_in[0]->tracker.most[0] != ch->handler->source_pt.payload_type)
-			shutdown = true;
+		else {
+			shutdown = true; // default if no most used PTs are known
+
+			for (int i = 0; i < ps->ssrc_in[0]->tracker.most_len; i++) {
+				unsigned char most_pt = ps->ssrc_in[0]->tracker.most[i];
+				shutdown = false;
+				// we are good if the most used PT is
+				// either us
+				if (ch->handler->source_pt.payload_type == most_pt)
+					break;
+				// or our input PT (which is the audio PT if we are supplemental)
+				if (ch->handler->input_handler && ch->handler->input_handler->source_pt.payload_type == most_pt)
+					break;
+
+				// looks like codec change, but...
+				shutdown = true;
+
+				// another possibility is that the most used PT is actually a supplemental type. check this,
+				// and if true move on to the next most used PT.
+				struct rtp_payload_type *pt = g_hash_table_lookup(ps->media->codecs.codecs, GUINT_TO_POINTER(most_pt));
+				if (pt->codec_def && pt->codec_def->supplemental)
+					continue;
+
+				// all other cases: codec change
+				break;
+			}
+		}
 
 		if (shutdown) {
 			ilogs(dtx, LOG_DEBUG, "DTX buffer for %lx has been shut down", (unsigned long) dtxb->ssrc);

--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -3003,7 +3003,7 @@ static void __dtx_send_later(struct codec_timer *ct) {
 				// another possibility is that the most used PT is actually a supplemental type. check this,
 				// and if true move on to the next most used PT.
 				struct rtp_payload_type *pt = g_hash_table_lookup(ps->media->codecs.codecs, GUINT_TO_POINTER(most_pt));
-				if (pt->codec_def && pt->codec_def->supplemental)
+				if (pt && pt->codec_def && pt->codec_def->supplemental)
 					continue;
 
 				// all other cases: codec change

--- a/daemon/websocket.c
+++ b/daemon/websocket.c
@@ -646,7 +646,6 @@ static int websocket_conn_init(struct lws *wsi, void *p) {
 	int fd = lws_get_socket_fd(wsi);
 #endif
 
-	memset(wc, 0, sizeof(*wc));
 
 	if (getpeername(fd, (struct sockaddr *) &sa, &sl)) {
 		ilogs(http, LOG_ERR, "Failed to get remote address of HTTP/WS connection (fd %i): %s",
@@ -656,11 +655,6 @@ static int websocket_conn_init(struct lws *wsi, void *p) {
 		endpoint_parse_sockaddr_storage(&wc->endpoint, &sa);
 	}
 
-	wc->wsi = wsi;
-	mutex_init(&wc->lock);
-	cond_init(&wc->cond);
-	g_queue_init(&wc->messages);
-	g_queue_push_tail(&wc->output_q, websocket_output_new());
 	wc->wm = websocket_message_new(wc);
 
 	return 0;

--- a/daemon/websocket.c
+++ b/daemon/websocket.c
@@ -489,7 +489,8 @@ static int websocket_http_get(struct websocket_conn *wc) {
 		return 0;
 	}
 
-	websocket_message_push(wc, handler);
+	// websocket_message_push(wc, handler);
+	handler(wm);
 	return 0;
 }
 

--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -2152,7 +2152,7 @@ static int amr_decoder_input(decoder_t *dec, const str *data, GQueue *out) {
 err:
 	if (err)
 		ilog(LOG_WARN | LOG_FLAG_LIMIT, "Error unpacking AMR packet: %s", err);
-
+	g_queue_clear(&toc);
 	return -1;
 }
 static unsigned int amr_encoder_find_next_mode(encoder_t *enc) {

--- a/lib/codeclib.c
+++ b/lib/codeclib.c
@@ -2008,13 +2008,14 @@ static void amr_bitrate_tracker(decoder_t *dec, unsigned int ft) {
 static int amr_decoder_input(decoder_t *dec, const str *data, GQueue *out) {
 	const char *err = NULL;
 
+	GQueue toc = G_QUEUE_INIT;
+
 	if (!data || !data->s)
 		goto err;
 
 	bitstr d;
 	bitstr_init(&d, data);
 
-	GQueue toc = G_QUEUE_INIT;
 	unsigned int ill = 0, ilp = 0;
 
 	unsigned char cmr_chr[2];


### PR DESCRIPTION
The PT tracker doesn't distinguish between audio/media types and
supplemental types, so in order not to break DTMF handling we must take
all combinations of primary (audio/media) types and supplemental types
as both input types and handler types into account.

Fix-up for 74075f6396d084762768429f1b92eabf48b30b94
Fix-up for I57e1278e4fad157083d9526d4829f2940581687f

closes #1508
possibly also #1504

Change-Id: If7b242def2d35fbed14b11d204ea328b8bfe5d79