### PR TITLE
rtpengine.service: match installation location in /usr/bin

### DIFF
--- a/el/rtpengine.service
+++ b/el/rtpengine.service
@@ -13,7 +13,7 @@ LimitNOFILE=150000
 RuntimeDirectory=rtpengine
 PIDFile=/run/rtpengine/rtpengine.pid
 ExecStartPre=+/usr/sbin/ngcp-rtpengine-iptables-setup start
-ExecStart=/usr/sbin/rtpengine --config-file=${CFG_FILE} --pidfile=${PID_FILE}
+ExecStart=/usr/bin/rtpengine --config-file=${CFG_FILE} --pidfile=${PID_FILE}
 ExecStopPost=+/usr/sbin/ngcp-rtpengine-iptables-setup stop
 RestartSec=3s
 TimeoutSec=15s


### PR DESCRIPTION
The installation location is `/usr/bin` but the systemd unit file was looking in `/usr/sbin`.

This PR updates the unit file to match the installation location.