### PR TITLE
Add TLS ALPN option to be set when connecting MQTT

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -559,6 +559,7 @@ static void options(int *argc, char ***argv) {
 #ifdef HAVE_MQTT
 		{ "mqtt-host",0,0,	G_OPTION_ARG_STRING,	&rtpe_config.mqtt_host,	"Mosquitto broker host or address",	"HOST|IP"},
 		{ "mqtt-port",0,0,	G_OPTION_ARG_INT,	&rtpe_config.mqtt_port,	"Mosquitto broker port number",		"INT"},
+		{ "mqtt-tls-alpn",0,0,	G_OPTION_ARG_STRING,	&rtpe_config.mqtt_tls_alpn,	"Mosquitto broker TLS ALPN",	"STRING"},
 		{ "mqtt-id",0,0,	G_OPTION_ARG_STRING,	&rtpe_config.mqtt_id,	"Mosquitto client ID",			"STRING"},
 		{ "mqtt-keepalive",0,0,	G_OPTION_ARG_INT,	&rtpe_config.mqtt_keepalive,"Seconds between mosquitto keepalives","INT"},
 		{ "mqtt-user",0,0,	G_OPTION_ARG_STRING,	&rtpe_config.mqtt_user,	"Username for mosquitto auth",		"USERNAME"},

--- a/daemon/mqtt.c
+++ b/daemon/mqtt.c
@@ -61,6 +61,14 @@ static int mqtt_connect(void) {
 		}
 	}
 
+    if (rtpe_config.mqtt_tls_alpn) {
+		int ret = mosquitto_string_option(mosq, MOSQ_OPT_TLS_ALPN, rtpe_config.mqtt_tls_alpn);
+		if (ret != MOSQ_ERR_SUCCESS) {
+			ilog(LOG_ERR, "Failed to set mosquitto TLS ALPN options: %s", mosquitto_strerror(errno));
+			return -1;
+		}
+    }
+
 	ret = mosquitto_connect(mosq, rtpe_config.mqtt_host, rtpe_config.mqtt_port,
 			rtpe_config.mqtt_keepalive);
 	if (ret != MOSQ_ERR_SUCCESS) {

--- a/daemon/rtpengine.pod
+++ b/daemon/rtpengine.pod
@@ -995,11 +995,14 @@ to enable authentication.
 
 =item B<--mqtt-keyfile=>I<FILE>
 
+=item B<--mqtt-tls-alpn=>I<STRING>
+
 Enable TLS to connect to Mosquitto broker, optionally with client certificate
 authentication. At least B<cafile> or B<capath> must be given to enable TLS. To
 enable client certificate authentication, both B<certfile> and B<keyfile> must
 be set. All files must be in PEM format. Password-proteted files are not
-supported.
+supported. The B<tls-alpn> can be set (e.g. mqtt) if a service like AWS IoT
+Core shares the same TLS port for two different network protocols.
 
 =item B<--mqtt-publish-qos=>B<0>|B<1>|B<2>
 

--- a/etc/rtpengine.conf
+++ b/etc/rtpengine.conf
@@ -118,6 +118,7 @@ recording-method = proc
 
 # mqtt-host = localhost
 # mqtt-port = 1883
+# mqtt-tls-alpn = mqtt
 # mqtt-id =
 # mqtt-user = foo
 # mqtt-pass = bar

--- a/include/main.h
+++ b/include/main.h
@@ -135,6 +135,7 @@ struct rtpengine_config {
 	int			poller_per_thread;
 	char			*mqtt_host;
 	int			mqtt_port;
+	char			*mqtt_tls_alpn;
 	char			*mqtt_id;
 	int			mqtt_keepalive;
 	char			*mqtt_user;


### PR DESCRIPTION
This is required to be set to "mqtt" for instance when connecting to the AWS IoT Core data endpoint at port 443 to indicate we're sending MQTT, because in that case websocket and mqtt shares the same port for whatever reason.