### PR TITLE
add mix_num_inputs variable to config file

### DIFF
--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -19,6 +19,7 @@
 #include "epoll.h"
 #include "inotify.h"
 #include "metafile.h"
+#include "mix.h"
 #include "garbage.h"
 #include "auxlib.h"
 #include "decoder.h"
@@ -38,6 +39,7 @@ char *output_dir = NULL;
 static char *output_format = NULL;
 int output_mixed;
 enum mix_method mix_method;
+int mix_num_inputs = NULL;
 int output_single;
 int output_enabled = 1;
 mode_t output_chmod;
@@ -190,6 +192,7 @@ static void options(int *argc, char ***argv) {
 		{ "mp3-bitrate",	0,   0, G_OPTION_ARG_INT,	&mp3_bitrate,	"Bits per second for MP3 encoding",	"INT"		},
 		{ "output-mixed",	0,   0, G_OPTION_ARG_NONE,	&output_mixed,	"Mix participating sources into a single output",NULL	},
 		{ "mix-method",		0,   0, G_OPTION_ARG_STRING,	&mix_method_str,"How to mix multiple sources",		"direct|channels"},
+		{ "mix-num-inputs",	0,   0, G_OPTION_ARG_INT,	&mix_num_inputs, "Set mix number input for channel",	"INT"		},
 		{ "output-single",	0,   0, G_OPTION_ARG_NONE,	&output_single,	"Create one output file for each source",NULL		},
 		{ "output-chmod",	0,   0, G_OPTION_ARG_STRING,	&chmod_mode,	"File mode for recordings",		"OCTAL"		},
 		{ "output-chmod-dir",	0,   0, G_OPTION_ARG_STRING,	&chmod_dir_mode,"Directory mode for recordings",	"OCTAL"		},
@@ -249,6 +252,9 @@ static void options(int *argc, char ***argv) {
 	else
 		die("Invalid 'output-storage' option");
 
+	if (mix_num_inputs == NULL)
+		mix_num_inputs = MIX_MAX_INPUTS;
+
 	if (!mix_method_str || !mix_method_str[0] || !strcmp(mix_method_str, "direct"))
 		mix_method = MM_DIRECT;
 	else if (!strcmp(mix_method_str, "channels"))
@@ -304,6 +310,7 @@ static void options_free(void) {
 	g_free(spool_dir);
 	g_free(output_dir);
 	g_free(output_format);
+//	g_free(mix_num_input);
 	g_free(c_mysql_host);
 	g_free(c_mysql_user);
 	g_free(c_mysql_pass);

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -259,10 +259,8 @@ static void options(int *argc, char ***argv) {
 	else
 		die("Invalid 'mix-method' option");
 
-	if (mix_num_inputs <= 0)
-		die("Invalid input value, it must be greater than zero");
-	if (mix_num_inputs > MIX_MAX_INPUTS)
-		die("Invalid input value, it must be less than or equal to %d", MIX_MAX_INPUTS);
+	if (mix_num_inputs <= 0 && mix_num_inputs > MIX_MAX_INPUTS)
+		die("Invalid input value, it must be greater than zero and must be less than or equal to %d", MIX_MAX_INPUTS);
 
 	if ((output_storage & OUTPUT_STORAGE_FILE) && !strcmp(output_dir, spool_dir))
 		die("The spool-dir cannot be the same as the output-dir");

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -260,7 +260,7 @@ static void options(int *argc, char ***argv) {
 		die("Invalid 'mix-method' option");
 
 	if (mix_num_inputs <= 0 && mix_num_inputs > MIX_MAX_INPUTS)
-		die("Invalid input value, it must be greater than zero and must be less than or equal to %d", MIX_MAX_INPUTS);
+		die("Invalid mix_num_inputs value, it must be between 1 and %d", MIX_MAX_INPUTS);
 
 	if ((output_storage & OUTPUT_STORAGE_FILE) && !strcmp(output_dir, spool_dir))
 		die("The spool-dir cannot be the same as the output-dir");

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -259,6 +259,11 @@ static void options(int *argc, char ***argv) {
 	else
 		die("Invalid 'mix-method' option");
 
+	if (mix_num_inputs <= 0)
+		die("Invalid input value, it must be greater than zero");
+	if (mix_num_inputs > MIX_MAX_INPUTS)
+		die("Invalid input value, it must be less than or equal to %d", MIX_MAX_INPUTS);
+
 	if ((output_storage & OUTPUT_STORAGE_FILE) && !strcmp(output_dir, spool_dir))
 		die("The spool-dir cannot be the same as the output-dir");
 

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -39,7 +39,7 @@ char *output_dir = NULL;
 static char *output_format = NULL;
 int output_mixed;
 enum mix_method mix_method;
-int mix_num_inputs = NULL;
+int mix_num_inputs = MIX_MAX_INPUTS;
 int output_single;
 int output_enabled = 1;
 mode_t output_chmod;
@@ -192,7 +192,7 @@ static void options(int *argc, char ***argv) {
 		{ "mp3-bitrate",	0,   0, G_OPTION_ARG_INT,	&mp3_bitrate,	"Bits per second for MP3 encoding",	"INT"		},
 		{ "output-mixed",	0,   0, G_OPTION_ARG_NONE,	&output_mixed,	"Mix participating sources into a single output",NULL	},
 		{ "mix-method",		0,   0, G_OPTION_ARG_STRING,	&mix_method_str,"How to mix multiple sources",		"direct|channels"},
-		{ "mix-num-inputs",	0,   0, G_OPTION_ARG_INT,	&mix_num_inputs, "Set mix number input for channel",	"INT"		},
+		{ "mix-num-inputs",	0,   0, G_OPTION_ARG_INT,	&mix_num_inputs, "Number of channels for recordings",	"INT"		},
 		{ "output-single",	0,   0, G_OPTION_ARG_NONE,	&output_single,	"Create one output file for each source",NULL		},
 		{ "output-chmod",	0,   0, G_OPTION_ARG_STRING,	&chmod_mode,	"File mode for recordings",		"OCTAL"		},
 		{ "output-chmod-dir",	0,   0, G_OPTION_ARG_STRING,	&chmod_dir_mode,"Directory mode for recordings",	"OCTAL"		},
@@ -252,9 +252,6 @@ static void options(int *argc, char ***argv) {
 	else
 		die("Invalid 'output-storage' option");
 
-	if (mix_num_inputs == NULL)
-		mix_num_inputs = MIX_MAX_INPUTS;
-
 	if (!mix_method_str || !mix_method_str[0] || !strcmp(mix_method_str, "direct"))
 		mix_method = MM_DIRECT;
 	else if (!strcmp(mix_method_str, "channels"))
@@ -310,7 +307,6 @@ static void options_free(void) {
 	g_free(spool_dir);
 	g_free(output_dir);
 	g_free(output_format);
-//	g_free(mix_num_input);
 	g_free(c_mysql_host);
 	g_free(c_mysql_user);
 	g_free(c_mysql_pass);

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -42,7 +42,6 @@ extern char *forward_to;
 extern endpoint_t tls_send_to_ep;
 extern int tls_resample;
 
-
 extern volatile int shutdown_flag;
 
 

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -24,6 +24,7 @@ extern char *spool_dir;
 extern char *output_dir;
 extern int output_mixed;
 extern enum mix_method mix_method;
+extern int mix_num_inputs;
 extern int output_single;
 extern int output_enabled;
 extern mode_t output_chmod;
@@ -40,6 +41,7 @@ extern int c_mysql_port;
 extern char *forward_to;
 extern endpoint_t tls_send_to_ep;
 extern int tls_resample;
+
 
 extern volatile int shutdown_flag;
 

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -77,13 +77,14 @@ static void meta_destroy(metafile_t *mf) {
 
 // mf is locked
 static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *content) {
+	dbg("Hello");
 	db_do_call(mf);
 	if (output_enabled && output_mixed && mf->recording_on) {
 		pthread_mutex_lock(&mf->mix_lock);
 		if (!mf->mix) {
 			mf->mix_out = output_new(output_dir, mf->parent, "mix", "mix");
 			if (mix_method == MM_CHANNELS)
-				mf->mix_out->channel_mult = MIX_NUM_INPUTS;
+				mf->mix_out->channel_mult = mix_num_inputs;
 			mf->mix = mix_new();
 			db_do_stream(mf, mf->mix_out, "mixed", NULL, 0);
 		}

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -77,7 +77,6 @@ static void meta_destroy(metafile_t *mf) {
 
 // mf is locked
 static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *content) {
-	dbg("Hello");
 	db_do_call(mf);
 	if (output_enabled && output_mixed && mf->recording_on) {
 		pthread_mutex_lock(&mf->mix_lock);

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -107,8 +107,6 @@ unsigned int mix_get_index(mix_t *mix, void *ptr) {
 
 
 int mix_config(mix_t *mix, const format_t *format) {
-
-
 	const char *err;
 	char args[512];
 
@@ -217,7 +215,6 @@ err:
 
 
 mix_t *mix_new() {
-
 	mix_t *mix = g_slice_alloc0(sizeof(*mix));
 	format_init(&mix->in_format);
 	format_init(&mix->out_format);

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -22,12 +22,12 @@ struct mix_s {
 		 out_format;
 
 	AVFilterGraph *graph;
-	AVFilterContext *src_ctxs[MIX_NUM_INPUTS];
-	uint64_t pts_offs[MIX_NUM_INPUTS]; // initialized at first input seen
-	uint64_t in_pts[MIX_NUM_INPUTS]; // running counter of next expected adjusted pts
-	struct timeval last_use[MIX_NUM_INPUTS]; // to recycle old mix inputs
-	void *input_ref[MIX_NUM_INPUTS]; // to avoid collisions in case of idx re-use
-	CH_LAYOUT_T channel_layout[MIX_NUM_INPUTS];
+	AVFilterContext *src_ctxs[MIX_MAX_INPUTS];
+	uint64_t pts_offs[MIX_MAX_INPUTS]; // initialized at first input seen
+	uint64_t in_pts[MIX_MAX_INPUTS]; // running counter of next expected adjusted pts
+	struct timeval last_use[MIX_MAX_INPUTS]; // to recycle old mix inputs
+	void *input_ref[MIX_MAX_INPUTS]; // to avoid collisions in case of idx re-use
+	CH_LAYOUT_T channel_layout[MIX_MAX_INPUTS];
 	AVFilterContext *amix_ctx;
 	AVFilterContext *sink_ctx;
 	unsigned int next_idx;
@@ -50,7 +50,7 @@ static void mix_shutdown(mix_t *mix) {
 		avfilter_free(mix->sink_ctx);
 	mix->sink_ctx = NULL;
 
-	for (unsigned int i = 0; i < MIX_NUM_INPUTS; i++) {
+	for (unsigned int i = 0; i < mix_num_inputs; i++) {
 		if (mix->src_ctxs[i])
 			avfilter_free(mix->src_ctxs[i]);
 		mix->src_ctxs[i] = NULL;
@@ -83,7 +83,7 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 
 unsigned int mix_get_index(mix_t *mix, void *ptr) {
 	unsigned int next = mix->next_idx++;
-	if (next < MIX_NUM_INPUTS) {
+	if (next < mix_num_inputs) {
 		// must be unused
 		mix->input_ref[next] = ptr;
 		return next;
@@ -92,7 +92,7 @@ unsigned int mix_get_index(mix_t *mix, void *ptr) {
 	// too many inputs - find one to re-use
 	struct timeval earliest = {0,};
 	next = 0;
-	for (unsigned int i = 0; i < MIX_NUM_INPUTS; i++) {
+	for (unsigned int i = 0; i < mix_num_inputs; i++) {
 		if (earliest.tv_sec == 0 || timeval_cmp(&earliest, &mix->last_use[i]) > 0) {
 			next = i;
 			earliest = mix->last_use[i];
@@ -107,6 +107,8 @@ unsigned int mix_get_index(mix_t *mix, void *ptr) {
 
 
 int mix_config(mix_t *mix, const format_t *format) {
+
+
 	const char *err;
 	char args[512];
 
@@ -135,7 +137,7 @@ int mix_config(mix_t *mix, const format_t *format) {
 	if (!flt)
 		goto err;
 
-	snprintf(args, sizeof(args), "inputs=%lu", (unsigned long) MIX_NUM_INPUTS);
+	snprintf(args, sizeof(args), "inputs=%lu", (unsigned long) mix_num_inputs);
 	err = "failed to create amix/amerge filter context";
 	if (avfilter_graph_create_filter(&mix->amix_ctx, flt, NULL, args, NULL, mix->graph))
 		goto err;
@@ -148,9 +150,9 @@ int mix_config(mix_t *mix, const format_t *format) {
 
 	CH_LAYOUT_T channel_layout, ext_layout;
 	DEF_CH_LAYOUT(&channel_layout, mix->in_format.channels);
-	DEF_CH_LAYOUT(&ext_layout, mix->in_format.channels * MIX_NUM_INPUTS);
+	DEF_CH_LAYOUT(&ext_layout, mix->in_format.channels * mix_num_inputs);
 
-	for (unsigned int i = 0; i < MIX_NUM_INPUTS; i++) {
+	for (unsigned int i = 0; i < mix_num_inputs; i++) {
 		dbg("init input ctx %i", i);
 
 		CH_LAYOUT_T ch_layout = channel_layout;
@@ -203,7 +205,7 @@ int mix_config(mix_t *mix, const format_t *format) {
 
 	mix->out_format = mix->in_format;
 	if (mix_method == MM_CHANNELS)
-		mix->out_format.channels *= MIX_NUM_INPUTS;
+		mix->out_format.channels *= mix_num_inputs;
 
 	return 0;
 
@@ -215,12 +217,13 @@ err:
 
 
 mix_t *mix_new() {
+
 	mix_t *mix = g_slice_alloc0(sizeof(*mix));
 	format_init(&mix->in_format);
 	format_init(&mix->out_format);
 	mix->sink_frame = av_frame_alloc();
 
-	for (unsigned int i = 0; i < MIX_NUM_INPUTS; i++)
+	for (unsigned int i = 0; i < mix_num_inputs; i++)
 		mix->pts_offs[i] = (uint64_t) -1LL;
 
 	return mix;
@@ -272,7 +275,7 @@ static void mix_silence_fill(mix_t *mix) {
 	if (mix->out_pts < mix->in_format.clockrate)
 		return;
 
-	for (unsigned int i = 0; i < MIX_NUM_INPUTS; i++) {
+	for (unsigned int i = 0; i < mix_num_inputs; i++) {
 		// check the pts of each input and give them max 0.5 second of delay.
 		// if they fall behind too much, fill input with silence. otherwise
 		// output stalls and won't produce media
@@ -285,7 +288,7 @@ int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *ptr, output_t *o
 	const char *err;
 
 	err = "index out of range";
-	if (idx >= MIX_NUM_INPUTS)
+	if (idx >= mix_num_inputs)
 		goto err;
 
 	err = "mixer not initialized";

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include <libavutil/frame.h>
+
 #define MIX_MAX_INPUTS 4
 
 mix_t *mix_new(void);

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -3,12 +3,10 @@
 
 #include "types.h"
 #include <libavutil/frame.h>
-
 #define MIX_MAX_INPUTS 4
 
 mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
-
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
 unsigned int mix_get_index(mix_t *, void *);

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -4,9 +4,7 @@
 #include "types.h"
 #include <libavutil/frame.h>
 
-
-#define MIX_NUM_INPUTS 4
-
+#define MIX_MAX_INPUTS 4
 
 mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);

--- a/recording-daemon/rtpengine-recording.pod
+++ b/recording-daemon/rtpengine-recording.pod
@@ -259,6 +259,10 @@ input is mono audio, then the mixed output file would contain 4 audio channels.
 This mixing method requires an output file format which supports these kinds of
 multi-channel audio formats (e.g. B<wav>).
 
+=item B<--mix_num_input=>I<INT>
+
+Change the number of recording channel in the output file. The value is between 1 to 4 (e.g. B<4>, which is also the default value).
+
 =item B<--output-chmod=>I<INT>
 
 Change the file permissions of recording files to the given mode. Must be given

--- a/recording-daemon/rtpengine-recording.pod
+++ b/recording-daemon/rtpengine-recording.pod
@@ -259,7 +259,7 @@ input is mono audio, then the mixed output file would contain 4 audio channels.
 This mixing method requires an output file format which supports these kinds of
 multi-channel audio formats (e.g. B<wav>).
 
-=item B<--mix_num_input=>I<INT>
+=item B<--mix-num-inputs=>I<INT>
 
 Change the number of recording channel in the output file. The value is between 1 to 4 (e.g. B<4>, which is also the default value).
 


### PR DESCRIPTION
 [Issue](https://github.com/sipwise/rtpengine/issues/1557)

Specify number of channel during recording process. It need to be defined on parameter --mix-num-channel in rtpengine-recording configuration file. If parameter not defined, it will create channel based on variable MIX_MAX_INPUTS value in mix.h 