### PR TITLE
Compatibility fixes for SDP session version randomization

### DIFF
--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -2715,7 +2715,7 @@ int sdp_replace(struct sdp_chopper *chop, GQueue *sessions, struct call_monologu
 		session->origin.version_output_pos = chop->output->len;
 		if (!monologue->sdp_version) {
 			monologue->sdp_version = session->origin.version_num;
-			if (monologue->sdp_version == 0 || monologue->sdp_version == ULLONG_MAX)
+			if (monologue->sdp_version == ULLONG_MAX)
 				monologue->sdp_version = (unsigned int)ssl_random();
 		}
 

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -2716,7 +2716,7 @@ int sdp_replace(struct sdp_chopper *chop, GQueue *sessions, struct call_monologu
 		if (!monologue->sdp_version) {
 			monologue->sdp_version = session->origin.version_num;
 			if (monologue->sdp_version == 0 || monologue->sdp_version == ULLONG_MAX)
-				monologue->sdp_version = ssl_random();
+				monologue->sdp_version = (unsigned int)ssl_random();
 		}
 
 		if (session->origin.parsed && flags->replace_origin &&


### PR DESCRIPTION
- Limit randomized SDP session version to 32-bit integer - many of the SIP stacks use 32-bit integers internally and the Asterisk chan_sip SDP decoder will cap version to 9223372036854775807.
- Avoid randomizing SDP session version at zero - zero is a valid version for new sessions (mentioned in RFC 2327) and still used by some SIP implementations.

If merged, a backport to LTS would be highly appreciated. Thanks.