### PR TITLE
Add an option to not send dtmf log events for injected dtmf

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2432,15 +2432,15 @@ static void __dtmf_dsp_callback(void *ptr, int code, int level, int delay) {
 	uint64_t ts = ch->last_dtmf_event_ts + delay;
 	ch->last_dtmf_event_ts = ts;
 	ts = av_rescale(ts, ch->encoder_format.clockrate, ch->dtmf_format.clockrate);
-	codec_add_dtmf_event(ch, code, level, ts);
+	codec_add_dtmf_event(ch, code, level, ts, false);
 }
 
-void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, uint64_t ts) {
+void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, uint64_t ts, bool injected) {
 	struct dtmf_event new_ev = { .code = code, .volume = level, .ts = ts };
 	ilogs(transcoding, LOG_DEBUG, "DTMF event state change: code %i, volume %i, TS %lu",
 			new_ev.code, new_ev.volume, (unsigned long) ts);
 	dtmf_dsp_event(&new_ev, &ch->dtmf_state, ch->handler->media, ch->handler->source_pt.clock_rate,
-			ts + ch->csch.first_ts);
+			ts + ch->csch.first_ts, injected);
 
 	// add to queue if we're doing PCM -> DTMF event conversion
 	// this does not capture events when doing DTMF delay (dtmf_payload_type == -1)

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -498,6 +498,7 @@ static void options(int *argc, char ***argv) {
 		{ "dtmf-log-ng-tcp", 0,0,	G_OPTION_ARG_NONE,	&rtpe_config.dtmf_via_ng,	"DTMF logging via TCP NG protocol",	NULL },
 		{ "dtmf-no-suppress", 0,0,G_OPTION_ARG_NONE,	&rtpe_config.dtmf_no_suppress,	"Disable audio suppression during DTMF events",	NULL },
 		{ "dtmf-digit-delay", 0,0,G_OPTION_ARG_INT,	&rtpe_config.dtmf_digit_delay,	"Delay in ms between DTMF digit for trigger detection",	NULL },
+		{ "dtmf-no-log-injects", 0,0,G_OPTION_ARG_NONE, &rtpe_config.dtmf_no_log_injects,  "Disable DTMF logging for events created by inject-DTMF function", NULL},
 #endif
 		{ "log-format",	0, 0,	G_OPTION_ARG_STRING,	&log_format,	"Log prefix format",		"default|parsable"},
 		{ "xmlrpc-format",'x', 0, G_OPTION_ARG_INT,	&rtpe_config.fmt,	"XMLRPC timeout request format to use. 0: SEMS DI, 1: call-id only, 2: Kamailio",	"INT"	},

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -1703,7 +1703,7 @@ static const struct streamhandler *__determine_handler(struct packet_stream *in,
 
 	if (!sh)
 		must_recrypt = true;
-	else if (dtmf_do_logging())
+	else if (dtmf_do_logging(false))
 		must_recrypt = true;
 	else if (MEDIA_ISSET(in->media, DTLS) || (out && MEDIA_ISSET(out->media, DTLS)))
 		must_recrypt = true;

--- a/daemon/rtpengine.pod
+++ b/daemon/rtpengine.pod
@@ -284,6 +284,10 @@ given address as UDP packets.
 If B<--listen-tcp-ng> is enabled, this will send DTMF events to all
 connected clients encoded in bencode format.
 
+=item B<--dtmf-no-log-injects>
+If B<--dtmf-no-log-injects> is enabled, DTMF events resulting from a
+call to inject-DTMF won't be sent to B<--dtmf-log-dest=> or B<--listen-tcp-ng>
+
 =item B<--dtmf-no-suppress>
 
 Some RTP clients continue to send audio RTP packets during a DTMF event,

--- a/etc/rtpengine.conf
+++ b/etc/rtpengine.conf
@@ -89,6 +89,8 @@ recording-method = proc
 # dtls-signature = sha-256
 # dtls-ciphers = DEFAULT:!NULL:!aNULL:!SHA256:!SHA384:!aECDH:!AESGCM+AES256:!aPSK
 
+# dtmf-no-log-injects = 0
+
 # graphite = 127.0.0.1:9006
 # graphite-interval = 60
 # graphite-prefix = foobar.

--- a/include/codec.h
+++ b/include/codec.h
@@ -148,7 +148,7 @@ void ensure_codec_def(struct rtp_payload_type *pt, struct call_media *media);
 void codec_handler_free(struct codec_handler **handler);
 bool codec_handlers_update(struct call_media *receiver, struct call_media *sink, const struct sdp_ng_flags *,
 		const struct stream_params *);
-void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, uint64_t ts);
+void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, uint64_t ts, bool injected);
 uint64_t codec_last_dtmf_event(struct codec_ssrc_handler *ch);
 uint64_t codec_encoder_pts(struct codec_ssrc_handler *ch);
 void codec_decoder_skip_pts(struct codec_ssrc_handler *ch, uint64_t);

--- a/include/dtmf.h
+++ b/include/dtmf.h
@@ -33,9 +33,9 @@ int dtmf_code_from_char(char);
 char dtmf_code_to_char(int code);
 const char *dtmf_inject(struct call_media *media, int code, int volume, int duration, int pause,
 		struct call_media *sink);
-bool dtmf_do_logging(void);
+bool dtmf_do_logging(bool injected);
 void dtmf_dsp_event(const struct dtmf_event *new_event, struct dtmf_event *cur_event,
-		struct call_media *media, int clockrate, uint64_t ts);
+		struct call_media *media, int clockrate, uint64_t ts, bool injected);
 enum block_dtmf_mode dtmf_get_block_mode(struct call *call, struct call_monologue *ml);
 bool is_pcm_dtmf_block_mode(enum block_dtmf_mode mode);
 bool is_dtmf_replace_mode(enum block_dtmf_mode mode);

--- a/include/main.h
+++ b/include/main.h
@@ -103,6 +103,7 @@ struct rtpengine_config {
 	int			dtmf_via_ng;
 	int			dtmf_no_suppress;
 	int			dtmf_digit_delay;
+	int			dtmf_no_log_injects;
 	enum endpoint_learning	endpoint_learning;
 	int                     jb_length;
 	int                     jb_clock_drift;


### PR DESCRIPTION
For cases where the same application is receiving DTMF over udp or tcp-ng, and also injecting DTMF, this option allows those injected DTMF to not be sent back on the udp/tcp-ng socket(s).