### PR TITLE
Redis fix for active-active

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -4698,6 +4698,7 @@ del_all:
 		ilog(LOG_INFO, "Deleting entire call");
 		rwlock_unlock_w(&c->master_lock);
 		call_destroy(c);
+		update = false;
 	}
 	goto success;
 

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -2743,6 +2743,9 @@ void redis_delete(struct call *c, struct redis *r) {
 	if (!r)
 		return;
 
+	if (c->foreign_call)
+		return;
+
 	if (delete_async) {
 		LOCK(&r->async_lock);
 		rwlock_lock_r(&c->master_lock);


### PR DESCRIPTION
Hello. We are having some issues with the redis notification thread in the active-active setup of rtpengine. I will try to make a big picture description of our setup and present the solution for those issues. Also want to ask what do you think of those changes and how should they get merged.

Active-Active setup description:

    - 2 x rtpengine machines, each can receive calls, each has a local read-only redis slave, used for reading and for incoming notifications
    - 1 x redis master, used by both rtpengines for writing and for sending notifications when something has been written into it


Let's consider the machine that has the OWN call as ``rtp1`` and the machine that has the FOREIGN call as "rtp2":

    1.rtp1 creates OWN call and writes it to the redis master
    2.redis master sends SET notification to rtp2 to create foreign call
    3.call ends eventually
    4.rtp1 destroys OWN call and writes it to redis master
    5.redis master sends DEL notification to rtp2 to delete foreign call


Solutions for the issues we are having:

    1. rtp2 to NOT delete foreign calls on redis_delete(), because foreign calls will be deleted via receiving DEL notification.
    2. rtp1 to NOT do a redis_update_onekey (e.g. in daemon/call.c) after destroying the call, which will result in sending another SET to rtp2 and another foreign call creation.


I think the solution specific to our setup can be merged via 2 separate config params, which will not impact current codebase. What do you think?

Thank you,
Stefan