### PR TITLE
Handle dtls retransmissions (continuation of PR #1311)

### DIFF
--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -480,13 +480,13 @@ int dtls_verify_cert(struct packet_stream *ps) {
 
 static int try_connect(struct dtls_connection *d) {
 	int ret, code;
-
-	if (d->connected)
-		return 0;
+	unsigned char buf[0x10000];
 
 	__DBG("try_connect(%i)", d->active);
 
-	if (d->active)
+	if (d->connected)
+		ret = SSL_read(d->ssl, buf, sizeof(buf)); /* retransmission after connected - handshake lost */
+	else if (d->active)
 		ret = SSL_connect(d->ssl);
 	else
 		ret = SSL_accept(d->ssl);
@@ -496,13 +496,26 @@ static int try_connect(struct dtls_connection *d) {
 	ret = 0;
 	switch (code) {
 		case SSL_ERROR_NONE:
-			ilogs(crypto, LOG_DEBUG, "DTLS handshake successful");
-			d->connected = 1;
-			ret = 1;
+			if (d->connected) {
+				ilogs(crypto, LOG_WARNING, "DTLS data received after handshake, code: %i", code);
+			} else {
+				ilogs(crypto, LOG_DEBUG, "DTLS handshake successful");
+				d->connected = 1;
+				ret = 1;
+			}
 			break;
 
 		case SSL_ERROR_WANT_READ:
 		case SSL_ERROR_WANT_WRITE:
+			if (d->connected) {
+				ilogs(crypto, LOG_WARNING, "DTLS data received after handshake, code: %i", code);
+			}
+			break;
+                case SSL_ERROR_ZERO_RETURN:
+			if (d->connected) {
+				ilogs(crypto, LOG_DEBUG, "DTLS peer has closed the connection");
+				ret = -2;
+			}
 			break;
 
 		default:
@@ -723,6 +736,11 @@ int dtls(struct stream_fd *sfd, const str *s, const endpoint_t *fsin) {
 	if (ret == -1) {
 		ilogs(srtp, LOG_ERROR, "DTLS error on local port %u", sfd->socket.local.port);
 		/* fatal error */
+		dtls_connection_cleanup(d);
+		return 0;
+	}
+	if (ret == -2) {
+		/* peer close connection */
 		dtls_connection_cleanup(d);
 		return 0;
 	}


### PR DESCRIPTION
Hi !

Want to revive the PR #1311 about DTLS retransmissions, i made little modifications in code.

Step be step.
I use rtengine version mr9.5.5.0 with openssl 1.1.1-1ubuntu2.1~18.04.21 on Ubuntu 18.04.6 LTS.
Loss of final TLS session ticket from rtpengine in my case can reach up to 10% especially on poor mobile networks,
symptoms are the same as in #1311, so i make test env to reproduce problem, this can be done easily with iptables 
at customer side (opposite to rtpengine):

```
iptables -A INPUT -s XX.XX.XX.XX/32 -p udp -m u32 --u32 "0x19&0xff=20:63" -j LOG --log-prefix "DTLS packet"
iptables -A INPUT -s XX.XX.XX.XX/32 -p udp -m u32 --u32 "0x19&0xff=20:63&&0x26&0xff=0x4" -j LOG --log-prefix "DTLS Ticket"
iptables -A INPUT -s XX.XX.XX.XX/32 -p udp -m u32 --u32 "0x19&0xff=20:63&&0x26&0xff=0x4" -m statistic --mode nth ! --every 4 --packet 1 -j DROP
```
where XX.XX.XX.XX is the ip of rtpengine.

In clear rtpengine loss of session ticket looks like this (wireshark at customer side):
![DTLS-bad](https://user-images.githubusercontent.com/26491743/232497281-7097b1e4-9d86-4da3-bab4-ad19299124f0.png)

logs from rtpengine (only relative to DTLS):
```
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] Handling packet on: XXX.XXX.51.34:55592
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000001012b0b0001
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] try_connect(0)
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44 port 30044]: [crypto] DTLS: Peer certificate accepted
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [crypto] DTLS handshake successful
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44 port 30044]: [crypto] DTLS-SRTP successfully negotiated using AEAD_AES_256_GCM
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] SRTP keys, incoming:
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] --- AEAD_AES_256_GCM key WCOybiLnontUsDDcKF7QJ462KbUt9LSWpZRcWwfP8PI= salt PNd+lZxk5b+PhASe
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] SRTP keys, outgoing:
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] --- AEAD_AES_256_GCM key hv5+dPD++AKWZzSjLRQOqg8dxF6U3wcOC/49JW0EGwA= salt EFNCRIe0zADuHAiw
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44 port 30044]: [crypto] DTLS-SRTP successfully negotiated using AEAD_AES_256_GCM
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] SRTP keys, incoming:
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] --- AEAD_AES_256_GCM key WCOybiLnontUsDDcKF7QJ462KbUt9LSWpZRcWwfP8PI= salt PNd+lZxk5b+PhASe
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] SRTP keys, outgoing:
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] --- AEAD_AES_256_GCM key hv5+dPD++AKWZzSjLRQOqg8dxF6U3wcOC/49JW0EGwA= salt EFNCRIe0zADuHAiw
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet output: len 579 16fefd000000000000000900f3040001
Apr 17 14:09:36 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Sending DTLS packet
...
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000005012b0b0001
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000009012b0b0001
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd000000000000000d012b0b0001
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000011012b0b0001
Apr 17 14:09:37 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:38 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000015012b0b0001
Apr 17 14:09:38 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:40 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000019012b0b0001
Apr 17 14:09:40 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:44 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd000000000000001d012b0b0001
Apr 17 14:09:44 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:51 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [internals] dtls packet input: len 578 16fefd0000000000000021012b0b0001
Apr 17 14:09:51 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44 port 30044]: [srtp] Processing incoming DTLS packet
...
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] Final packet stats:
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] --- Tag 'sd5fhikid0' (label 'A'), created 0:22 ago for branch '', in dialogue with 'USHB5Uy6Q176p'
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] ------ Media #1 (audio over RTP/SAVPF) using unknown codec
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] --------- Port   YYY.YYY.228.186:30044 <>    XXX.XXX.51.34:55592, SSRC 0, 1 p, 64 b, 0 e, 22 ts
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] --- Tag 'USHB5Uy6Q176p' (label 'B'), created 0:22 ago for branch '', in dialogue with 'sd5fhikid0'
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] ------ Media #1 (audio over RTP/AVP) using opus/48000/2
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: INFO: [2srd83lf9lb450u3dn44]: [core] --------- Port XXXX:XXXX:XXXX:XXXX::e3:30054 <> YYYY:YYYY:YYYY:YYYY::2102:25660, SSRC 68428a18, 806 p, 263586 b, 0 e, 5 ts
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44]: [internals] dtls_shutdown
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: message repeated 2 times: [ DEBUG: [2srd83lf9lb450u3dn44]: [internals] dtls_shutdown]
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44]: [crypto] Resetting DTLS connection context
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44]: [crypto] Resetting DTLS connection context
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44]: [core] Resetting crypto context
Apr 17 14:09:58 taxi-sas-appreg-dev rtpengine[332]: DEBUG: [2srd83lf9lb450u3dn44]: [internals] dtls_shutdown
```

Customer (i use chrome) can't establish srtp session so no audio.

This is after patch, iptables drops several session tickets, rtpengine make retransmission:
![DTLS-good](https://user-images.githubusercontent.com/26491743/232499338-508773c8-2fc7-4e08-b935-6e231927aa1a.png)

logs:
```
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] Handling packet on: XXX.XXX.51.34:41099
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet input: len 577 16fefd0000000000000001012b0b0001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Processing incoming DTLS packet
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] try_connect(0)
Apr 17 15:07:15 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS: Peer certificate accepted
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS handshake successful
Apr 17 15:07:15 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS-SRTP successfully negotiated using AEAD_AES_256_GCM
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] SRTP keys, incoming:
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] --- AEAD_AES_256_GCM key 4fbI4NuvpS0JpLeOSireAysF4o1/PaGWRjRE4ehqasA= salt GeXQQUdY5zDUSyxx
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] SRTP keys, outgoing:
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] --- AEAD_AES_256_GCM key vj2Z2wD1BfDv49ZQKlgpgWoNkfrgbjHBS0SwpODnYB4= salt jrxHTuJN9ElUXkR+
Apr 17 15:07:15 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS-SRTP successfully negotiated using AEAD_AES_256_GCM
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] SRTP keys, incoming:
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] --- AEAD_AES_256_GCM key 4fbI4NuvpS0JpLeOSireAysF4o1/PaGWRjRE4ehqasA= salt GeXQQUdY5zDUSyxx
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] SRTP keys, outgoing:
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] --- AEAD_AES_256_GCM key vj2Z2wD1BfDv49ZQKlgpgWoNkfrgbjHBS0SwpODnYB4= salt jrxHTuJN9ElUXkR+
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet output: len 579 16fefd000000000000000900f3040001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Sending DTLS packet
...
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet input: len 577 16fefd0000000000000005012b0b0001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Processing incoming DTLS packet
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] try_connect(0)
Apr 17 15:07:15 test-env rtpengine[4173]: WARNING: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS data received after handshake, code: 2
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet output: len 579 16fefd000000000000000c00f3040001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Sending DTLS packet
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] Handling packet on: XXX.XXX.51.34:41099
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet input: len 577 16fefd0000000000000009012b0b0001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Processing incoming DTLS packet
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] try_connect(0)
Apr 17 15:07:15 test-env rtpengine[4173]: WARNING: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS data received after handshake, code: 2
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet output: len 579 16fefd000000000000000f00f3040001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Sending DTLS packet
...

Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] Handling packet on: XXX.XXX.51.34:41099
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet input: len 577 16fefd000000000000000d012b0b0001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Processing incoming DTLS packet
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] try_connect(0)
Apr 17 15:07:15 test-env rtpengine[4173]: WARNING: [2srd8opih2406ul08uk3 port 30010]: [crypto] DTLS data received after handshake, code: 2
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [internals] dtls packet output: len 579 16fefd000000000000001200f3040001
Apr 17 15:07:15 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3 port 30010]: [srtp] Sending DTLS packet
...
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [internals] Handling packet on: XXX.XXX.51.34:41099
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [internals] dtls packet input: len 39 15fefd0001000000000004001a000100
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [srtp] Processing incoming DTLS packet
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [internals] try_connect(0)
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [crypto] DTLS peer has closed the connection
Apr 17 15:07:51 test-env rtpengine[4173]: DEBUG: [crypto] Resetting DTLS connection context
...
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] Final packet stats:
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --- Tag 'h5qc7m8gr9' (label 'A'), created 0:42 ago for branch '', in dialogue with 'B4UcvBZyyBmQB'
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] ------ Media #1 (audio over RTP/SAVPF) using opus/48000/2
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --------- Port   YYY.YYY.228.186:30010 <>    XXX.XXX.51.34:41099, SSRC 2afd914c, 1777 p, 587143 b, 0 e, 6 ts
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --- SSRC 2afd914c
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] ------ Average MOS 3.9, lowest MOS 3.3 (at 0:09), highest MOS 4.3 (at 0:24) lost:0
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --- Tag 'B4UcvBZyyBmQB' (label 'B'), created 0:42 ago for branch '', in dialogue with 'h5qc7m8gr9'
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] ------ Media #1 (audio over RTP/AVP) using opus/48000/2
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --------- Port XXXX:XXXX:XXXX:XXXX::e3:30008 <> YYY:YYY:YYY:YYY::2102:25494, SSRC 6842979b, 1798 p, 588147 b, 0 e, 6 ts
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] --- SSRC 6842979b
Apr 17 15:07:57 test-env rtpengine[4173]: INFO: [2srd8opih2406ul08uk3]: [core] ------ Average MOS 4.1, lowest MOS 3.5 (at 0:12), highest MOS 4.3 (at 0:24) lost:4
Apr 17 15:07:57 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3]: [internals] dtls_shutdown
Apr 17 15:07:57 test-env rtpengine[4173]: message repeated 2 times: [ DEBUG: [2srd8opih2406ul08uk3]: [internals] dtls_shutdown]
Apr 17 15:07:57 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3]: [crypto] Resetting DTLS connection context
Apr 17 15:07:57 test-env rtpengine[4173]: DEBUG: [2srd8opih2406ul08uk3]: [internals] dtls_shutdown
```

So, looks like patch works. I use mr9.5 in production, but patch changes have no conflicts with other branches.

