### PR TITLE
MT#56627 el/rtpengine.spec: fix version handling for dkms

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -175,8 +175,8 @@ install -D -p -m644 kernel-module/xt_RTPENGINE.h \
 mkdir -p %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}
 install -D -p -m644 kernel-module/rtpengine_config.h \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/rtpengine_config.h
-install -D -p -m644 debian/dkms.conf.in %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
-sed -i -e "s/__VERSION__/%{version}-%{release}/g" %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
+install -D -p -m644 debian/ngcp-rtpengine-kernel-dkms.dkms %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
+sed -i -e "s/#MODULE_VERSION#/%{version}-%{release}/g" %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/dkms.conf
 
 %pre
 getent group %{name} >/dev/null || /usr/sbin/groupadd -r %{name}


### PR DESCRIPTION
In commit 427615d45b we switched to usage of dh-sequence-dkms.  By renaming debian/dkms.conf.in into debian/ngcp-rtpengine-kernel-dkms.dkms and replacing its `__VERSION__` with `#MODULE_VERSION#` we broke the shipped RPM spec file, which also relies on our dkms configuration file. Accordingly adapt el/rtpengine.spec.

Thanks to @themsley-voiceflex for the bug report
Closes #1650