### PR TITLE
recording-daemon: Insert silence frames as needed during TLS forwarding

### DIFF
--- a/lib/common.Makefile
+++ b/lib/common.Makefile
@@ -41,7 +41,7 @@ $(DAEMONSRCS) $(HASHSRCS):	$(patsubst %,../daemon/%,$(DAEMONSRCS)) $(patsubst %,
 			-M "date:$(shell date -I)" \
 			-o "$@"
 
-resample.c codeclib.strhash.c mix.c:	fix_frame_channel_layout.h
+resample.c codeclib.strhash.c mix.c packet.c:	fix_frame_channel_layout.h
 
 ifeq ($(with_transcoding),yes)
 codec.c:	dtmf_rx_fillin.h

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -171,6 +171,11 @@ no_recording:
 			ssrc->sent_intro = 1;
 		}
 
+		ssrc_tls_fwd_silence_frames_upto(ssrc, dec_frame, dec_frame->pts);
+		uint64_t next_pts = dec_frame->pts + dec_frame->nb_samples;
+		if (next_pts > ssrc->tls_in_pts)
+			ssrc->tls_in_pts = next_pts;
+
 		int linesize = av_get_bytes_per_sample(dec_frame->format) * dec_frame->nb_samples;
 		dbg("Writing %u bytes PCM to TLS", linesize);
 		streambuf_write(ssrc->tls_fwd_stream, (char *) dec_frame->extended_data[0], linesize);

--- a/recording-daemon/packet.h
+++ b/recording-daemon/packet.h
@@ -2,6 +2,7 @@
 #define _PACKET_H_
 
 #include "types.h"
+#include <libavutil/frame.h>
 
 void ssrc_close(ssrc_t *s);
 void ssrc_free(void *p);
@@ -9,5 +10,6 @@ void ssrc_free(void *p);
 void packet_process(stream_t *, unsigned char *, unsigned len);
 
 void ssrc_tls_state(ssrc_t *ssrc);
+void ssrc_tls_fwd_silence_frames_upto(ssrc_t *ssrc, AVFrame *frame, int64_t upto);
 
 #endif

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -87,6 +87,8 @@ struct ssrc_s {
 	format_t tls_fwd_format;
 	resample_t tls_fwd_resampler;
 	socket_t tls_fwd_sock;
+	uint64_t tls_in_pts;
+	AVFrame *tls_silence_frame;
 	//BIO *bio;
 	SSL_CTX *ssl_ctx;
 	SSL *ssl;


### PR DESCRIPTION
If the forwarded streams of a call are later combined without the inserted silence, the resulting mix may end up with the channels out of sync. This is already handled when outputting mixed files so the same functionality from mix.c has been added for tls forwarding


The same thing could arguably also be applied to the single channel output, in which case some refactoring may be better to split common bits out into other functions rather than a mostly copy/pasted function for inserting the silence based on the output type. However, if you're going to mix the single channel outputs then you'd probably just use output-mixed anyway