### PR TITLE
recording-daemon : notify-purge param removes a file if notify success

### DIFF
--- a/docs/rtpengine-recording.md
+++ b/docs/rtpengine-recording.md
@@ -311,10 +311,6 @@ sufficient for a standard installation of rtpengine.
 
     Disable TLS peer certificate verification for HTTPS requests.
 
-- __\-\-notify-purge__
-
-    Remove the local file if cURL successed.
-
 - __\-\-notify-concurrency=__*INT*
 
     The maximum number of HTTP requests to perform simultaneously.
@@ -331,6 +327,10 @@ sufficient for a standard installation of rtpengine.
     request behaves as HTTP POST (ignoring __\-\-notify-post__). Note that this option
     is incompatible with DB-only storage as no recording file exists on storage
     (see __output-storage__).
+
+- __\-\-notify-purge__
+
+    Remove the local file if cURL successed. Note that this option is only useful if __\-\-notify-record__ is also enabled.
 
 ## EXIT STATUS
 

--- a/docs/rtpengine-recording.md
+++ b/docs/rtpengine-recording.md
@@ -311,6 +311,10 @@ sufficient for a standard installation of rtpengine.
 
     Disable TLS peer certificate verification for HTTPS requests.
 
+- __\-\-notify-purge__
+
+    Remove the local file if cURL successed.
+
 - __\-\-notify-concurrency=__*INT*
 
     The maximum number of HTTP requests to perform simultaneously.

--- a/etc/rtpengine-recording.conf
+++ b/etc/rtpengine-recording.conf
@@ -59,5 +59,6 @@ table = 0
 # notify-uri = https://example.com/rec/finished
 # notify-post = false
 # notify-no-verify = false
+# notify-purge = false
 # notify-concurrency = 5
 # notify-retries = 10

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -62,6 +62,7 @@ int tls_resample = 8000;
 char *notify_uri;
 int notify_post;
 int notify_nverify;
+int notify_purge;
 int notify_threads = 5;
 int notify_retries = 10;
 int notify_record;
@@ -220,6 +221,7 @@ static void options(int *argc, char ***argv) {
 		{ "notify-no-verify", 	0,   0, G_OPTION_ARG_NONE,	&notify_nverify,"Don't verify HTTPS peer certificate",	NULL		},
 		{ "notify-concurrency",	0,   0, G_OPTION_ARG_INT,	&notify_threads,"How many simultaneous requests",	"INT"		},
 		{ "notify-retries",	0,   0, G_OPTION_ARG_INT,	&notify_retries,"How many times to retry failed requesets","INT"	},
+		{ "notify-purge", 	0,   0, G_OPTION_ARG_STRING,	&notify_purge,	"Remove the local file if notify success", NULL		},
 #if CURL_AT_LEAST_VERSION(7,56,0)
 		{ "notify-record", 	0,   0, G_OPTION_ARG_NONE,      &notify_record, "Also attach recorded file to request", NULL            },
 #endif

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -62,10 +62,10 @@ int tls_resample = 8000;
 char *notify_uri;
 int notify_post;
 int notify_nverify;
-int notify_purge;
 int notify_threads = 5;
 int notify_retries = 10;
 int notify_record;
+int notify_purge;
 
 static GQueue threads = G_QUEUE_INIT; // only accessed from main thread
 
@@ -221,9 +221,9 @@ static void options(int *argc, char ***argv) {
 		{ "notify-no-verify", 	0,   0, G_OPTION_ARG_NONE,	&notify_nverify,"Don't verify HTTPS peer certificate",	NULL		},
 		{ "notify-concurrency",	0,   0, G_OPTION_ARG_INT,	&notify_threads,"How many simultaneous requests",	"INT"		},
 		{ "notify-retries",	0,   0, G_OPTION_ARG_INT,	&notify_retries,"How many times to retry failed requesets","INT"	},
-		{ "notify-purge", 	0,   0, G_OPTION_ARG_STRING,	&notify_purge,	"Remove the local file if notify success", NULL		},
 #if CURL_AT_LEAST_VERSION(7,56,0)
-		{ "notify-record", 	0,   0, G_OPTION_ARG_NONE,      &notify_record, "Also attach recorded file to request", NULL            },
+		{ "notify-record", 	0,   0, G_OPTION_ARG_NONE,	&notify_record, "Also attach recorded file to request", NULL		},
+		{ "notify-purge", 	0,   0, G_OPTION_ARG_NONE,	&notify_purge,	"Remove the local file if notify success", NULL		},
 #endif
 		{ NULL, }
 	};

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -44,10 +44,10 @@ extern int tls_resample;
 extern char *notify_uri;
 extern int notify_post;
 extern int notify_nverify;
-extern int notify_purge;
 extern int notify_threads;
 extern int notify_retries;
 extern int notify_record;
+extern int notify_purge;
 
 extern volatile int shutdown_flag;
 

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -44,6 +44,7 @@ extern int tls_resample;
 extern char *notify_uri;
 extern int notify_post;
 extern int notify_nverify;
+extern int notify_purge;
 extern int notify_threads;
 extern int notify_retries;
 extern int notify_record;

--- a/recording-daemon/notify.c
+++ b/recording-daemon/notify.c
@@ -125,6 +125,14 @@ static void do_notify(void *p, void *u) {
 	/* success */
 
 	ilog(LOG_NOTICE, "HTTP notification for '%s%s%s' was successful", FMT_M(req->name));
+
+	if (notify_purge) {
+		if (remove(req->full_filename_path) == 0) {
+			ilog(LOG_NOTICE, "File '%s' deleted successfully.\n", FMT_M(req->full_filename_path));
+		} else {
+			ilog(LOG_ERR, "File '%s' could not be deleted.\n", FMT_M(req->full_filename_path));
+		}
+	}
 	goto cleanup;
 
 fail:

--- a/recording-daemon/notify.c
+++ b/recording-daemon/notify.c
@@ -126,8 +126,8 @@ static void do_notify(void *p, void *u) {
 
 	ilog(LOG_NOTICE, "HTTP notification for '%s%s%s' was successful", FMT_M(req->name));
 
-	if (notify_purge) {
-		if (remove(req->full_filename_path) == 0) {
+	if (notify_record && notify_purge) {
+		if (unlink(req->full_filename_path) == 0) {
 			ilog(LOG_NOTICE, "File '%s' deleted successfully.\n", FMT_M(req->full_filename_path));
 		} else {
 			ilog(LOG_ERR, "File '%s' could not be deleted.\n", FMT_M(req->full_filename_path));


### PR DESCRIPTION
Hi,

We wanted rtpengine to remove records when a notify was successful. We implemented it.  
When a POST request success, we remove the output file if notify-purge option is enabled.