### PR TITLE
Fix for audio stuttering (inserted silence frames)

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -3480,7 +3480,7 @@ static void add_stream_packet(struct re_stream *stream, struct re_stream_packet 
 
 	/* discard older packets */
 	while (stream->list_count > stream->info.max_packets) {
-		DBG("discarding old packet from queue\n");
+        log_err("Queue is full, discarding old packet from queue");
 		packet = list_first_entry(&stream->packet_list, struct re_stream_packet, list_entry);
 		list_del(&packet->list_entry);
 		list_add(&packet->list_entry, &delete_list);

--- a/lib/g729.Makefile
+++ b/lib/g729.Makefile
@@ -9,6 +9,7 @@ else
 # system generic
 ifneq (,$(wildcard /usr/include/bcg729/decoder.h))
 have_bcg729 := yes
+bcg729_lib := -lbcg729
 else
 # /usr/src
 ifneq (,$(wildcard /usr/src/bcg729/include/bcg729/decoder.h))


### PR DESCRIPTION
Hi Richard,

Here's my fix for an issue we had with rtpengine and rtpengine-recording. I saw that the wav files produced by rtpengine-recording had silence frames inserted. The pcaps made by rtpengine where fine. The strange thing was that this happened even with a very small load. I've tested with only one concurrent call, in series with 5 calls of each 2 minutes each. Usually 2 out of 5 calls had missing frames. I found out that the kernel module reported that the queue was full.
This can (in my opinion) only be caused by th recording-daemon not reading fast enough. I made a small modification, now the file descriptor is tested after a frame is read if there is more data available (with a poll()). If so, the next frame is also processed.
This was the queue does not fill up anymore.  