### PR TITLE
Replace bash shebangs with sh

### DIFF
--- a/utils/build_test_wrapper
+++ b/utils/build_test_wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 TARGET=$1
 ROOT=$(echo "$TARGET" | sed 's/\.h$//')
 if test "x$MAKE" = x; then

--- a/utils/patch-kernel
+++ b/utils/patch-kernel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if test "$1" != magic; then
 	echo


### PR DESCRIPTION
There are no bash features in these scripts, and some distributions don't install bash by default.