### PR TITLE
Rename aux -> helpers

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -78,7 +78,7 @@ endif
 
 include ../lib/mqtt.Makefile
 
-SRCS=		main.c kernel.c poller.c aux.c control_tcp.c call.c control_udp.c redis.c \
+SRCS=		main.c kernel.c poller.c helpers.c control_tcp.c call.c control_udp.c redis.c \
 		bencode.c cookie_cache.c udp_listener.c control_ng.strhash.c sdp.strhash.c stun.c rtcp.c \
 		crypto.c rtp.c call_interfaces.strhash.c dtls.c log.c cli.c graphite.c ice.c \
 		media_socket.c homer.c recording.c statistics.c cdr.c ssrc.c iptables.c tcp_listener.c \

--- a/daemon/bencode.c
+++ b/daemon/bencode.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <json-glib/json-glib.h>
-#include "aux.h"
+#include "helpers.h"
 
 /* set to 0 for alloc debugging, e.g. through valgrind */
 #define BENCODE_MIN_BUFFER_PIECE_LEN	512

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -19,7 +19,7 @@
 #include <inttypes.h>
 
 #include "poller.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "kernel.h"
 #include "control_tcp.h"

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -9,7 +9,7 @@
 
 #include "call_interfaces.h"
 #include "call.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "redis.h"
 #include "sdp.h"

--- a/daemon/cli.c
+++ b/daemon/cli.c
@@ -11,7 +11,7 @@
 #include <stdbool.h>
 
 #include "poller.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "log_funcs.h"
 #include "call.h"

--- a/daemon/control_tcp.c
+++ b/daemon/control_tcp.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 
 #include "poller.h"
-#include "aux.h"
+#include "helpers.h"
 #include "streambuf.h"
 #include "log.h"
 #include "call.h"

--- a/daemon/control_udp.c
+++ b/daemon/control_udp.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 
 #include "poller.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "call.h"
 #include "udp_listener.h"

--- a/daemon/cookie_cache.c
+++ b/daemon/cookie_cache.c
@@ -4,7 +4,7 @@
 #include <glib.h>
 
 #include "compat.h"
-#include "aux.h"
+#include "helpers.h"
 #include "poller.h"
 #include "str.h"
 

--- a/daemon/crypto.c
+++ b/daemon/crypto.c
@@ -8,7 +8,7 @@
 #include "xt_RTPENGINE.h"
 
 #include "str.h"
-#include "aux.h"
+#include "helpers.h"
 #include "rtp.h"
 #include "rtcp.h"
 #include "log.h"

--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -13,7 +13,7 @@
 #include <time.h>
 
 #include "str.h"
-#include "aux.h"
+#include "helpers.h"
 #include "crypto.h"
 #include "log.h"
 #include "call.h"

--- a/daemon/helpers.c
+++ b/daemon/helpers.c
@@ -1,4 +1,4 @@
-#include "aux.h"
+#include "helpers.h"
 #include <string.h>
 #include <stdio.h>
 #include <glib.h>

--- a/daemon/homer.c
+++ b/daemon/homer.c
@@ -10,7 +10,7 @@
 #include <sys/time.h>
 
 #include "log.h"
-#include "aux.h"
+#include "helpers.h"
 #include "str.h"
 
 

--- a/daemon/ice.c
+++ b/daemon/ice.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include "str.h"
 #include "call.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "obj.h"
 #include "stun.h"

--- a/daemon/iptables.c
+++ b/daemon/iptables.c
@@ -20,7 +20,7 @@ int (*iptables_del_rule)(const socket_t *local_sock);
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "socket.h"
 

--- a/daemon/kernel.c
+++ b/daemon/kernel.c
@@ -11,7 +11,7 @@
 
 #include "xt_RTPENGINE.h"
 
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 
 

--- a/daemon/load.c
+++ b/daemon/load.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "main.h"
 

--- a/daemon/log_funcs.h
+++ b/daemon/log_funcs.h
@@ -1,7 +1,7 @@
 #ifndef __LOG_FUNCS_H__
 #define __LOG_FUNCS_H__
 
-#include "aux.h"
+#include "helpers.h"
 #include "obj.h"
 #include "call.h"
 #include "media_socket.h"

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -25,7 +25,7 @@
 #include "control_tcp.h"
 #include "control_udp.h"
 #include "control_ng.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "call.h"
 #include "kernel.h"

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -15,7 +15,7 @@
 #include "xt_RTPENGINE.h"
 #include "rtcp.h"
 #include "sdp.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log_funcs.h"
 #include "poller.h"
 #include "recording.h"

--- a/daemon/poller.c
+++ b/daemon/poller.c
@@ -17,7 +17,7 @@
 #include <hiredis/adapters/libevent.h>
 
 
-#include "aux.h"
+#include "helpers.h"
 #include "obj.h"
 #include "log_funcs.h"
 

--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 
 #include "compat.h"
-#include "aux.h"
+#include "helpers.h"
 #include "call.h"
 #include "log.h"
 #include "log_funcs.h"

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -1,6 +1,6 @@
 #include "ssrc.h"
 #include <glib.h>
-#include "aux.h"
+#include "helpers.h"
 #include "call.h"
 #include "rtplib.h"
 #include "codeclib.h"

--- a/daemon/stun.c
+++ b/daemon/stun.c
@@ -10,7 +10,7 @@
 
 #include "compat.h"
 #include "str.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "ice.h"
 #include "ssllib.h"

--- a/daemon/tcp_listener.c
+++ b/daemon/tcp_listener.c
@@ -5,7 +5,7 @@
 #include "poller.h"
 #include "obj.h"
 #include "socket.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log.h"
 #include "streambuf.h"
 #include "media_socket.h"

--- a/daemon/timerthread.c
+++ b/daemon/timerthread.c
@@ -1,5 +1,5 @@
 #include "timerthread.h"
-#include "aux.h"
+#include "helpers.h"
 #include "log_funcs.h"
 
 

--- a/daemon/udp_listener.c
+++ b/daemon/udp_listener.c
@@ -8,7 +8,7 @@
 #include <errno.h>
 
 #include "poller.h"
-#include "aux.h"
+#include "helpers.h"
 #include "str.h"
 #include "log.h"
 #include "obj.h"

--- a/debian/changelog
+++ b/debian/changelog
@@ -3297,7 +3297,7 @@ ngcp-rtpengine (3.3.0.0+0~mr4.0.0.0) unstable; urgency=low
   * [02d27d5] MT#10583 support b2bua callback to sip proxy address
   * [43cd3f5] reset other side's crypto params only in passthru mode
   * [2af682b] use SSL_CTX_set_read_ahead to fix for openssl 1.0.1k
-  * [e24253a] move parse_ip(6)_port into aux.h
+  * [e24253a] move parse_ip(6)_port into helpers.h
   * [a81588e] provide convenience function get_log_level()
   * [37d98ad] dump DTLS cert and keys
   * [57c0a84] add locking to totalstats

--- a/include/cdr.h
+++ b/include/cdr.h
@@ -8,7 +8,7 @@
 #ifndef CDR_H_
 #define CDR_H_
 
-#include "aux.h"
+#include "helpers.h"
 
 struct call;
 enum tag_type;

--- a/include/codec.h
+++ b/include/codec.h
@@ -7,7 +7,7 @@
 #include <stdbool.h>
 #include "str.h"
 #include "codeclib.h"
-#include "aux.h"
+#include "helpers.h"
 #include "rtplib.h"
 #include "timerthread.h"
 #include "xt_RTPENGINE.h"

--- a/include/control_tcp.h
+++ b/include/control_tcp.h
@@ -10,7 +10,7 @@
 #include <glib.h>
 
 #include "obj.h"
-#include "aux.h"
+#include "helpers.h"
 #include "socket.h"
 
 

--- a/include/control_udp.h
+++ b/include/control_udp.h
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <netinet/in.h>
 #include "obj.h"
-#include "aux.h"
+#include "helpers.h"
 #include "cookie_cache.h"
 #include "udp_listener.h"
 #include "socket.h"

--- a/include/cookie_cache.h
+++ b/include/cookie_cache.h
@@ -3,7 +3,7 @@
 
 #include <time.h>
 #include <glib.h>
-#include "aux.h"
+#include "helpers.h"
 #include "str.h"
 
 struct cookie_cache_state {

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -7,7 +7,7 @@
 #include <glib.h>
 #include "compat.h"
 #include "str.h"
-#include "aux.h"
+#include "helpers.h"
 
 #define SRTP_MAX_MASTER_KEY_LEN 32
 #define SRTP_MAX_MASTER_SALT_LEN 14

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -1,5 +1,5 @@
-#ifndef __AUX_H__
-#define __AUX_H__
+#ifndef __HELPERS_H__
+#define __HELPERS_H__
 
 
 

--- a/include/ice.h
+++ b/include/ice.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 #include "str.h"
 #include "obj.h"
-#include "aux.h"
+#include "helpers.h"
 #include "media_socket.h"
 #include "socket.h"
 #include "timerthread.h"

--- a/include/main.h
+++ b/include/main.h
@@ -2,7 +2,7 @@
 #define _MAIN_H_
 
 
-#include "aux.h"
+#include "helpers.h"
 #include <glib.h>
 #include "socket.h"
 #include "auxlib.h"

--- a/include/media_socket.h
+++ b/include/media_socket.h
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include "str.h"
 #include "obj.h"
-#include "aux.h"
+#include "helpers.h"
 #include "dtls.h"
 #include "crypto.h"
 #include "socket.h"

--- a/include/recording.h
+++ b/include/recording.h
@@ -13,7 +13,7 @@
 #include <netinet/in.h>
 #include <pcap.h>
 #include "str.h"
-#include "aux.h"
+#include "helpers.h"
 #include "bencode.h"
 
 

--- a/include/redis.h
+++ b/include/redis.h
@@ -7,7 +7,7 @@
 #include <sys/types.h>
 #include "compat.h"
 #include "socket.h"
-#include "aux.h"
+#include "helpers.h"
 
 #include <glib.h>
 #include <sys/types.h>

--- a/include/ssrc.h
+++ b/include/ssrc.h
@@ -5,7 +5,7 @@
 #include <sys/types.h>
 #include <glib.h>
 #include "compat.h"
-#include "aux.h"
+#include "helpers.h"
 #include "obj.h"
 #include "codeclib.h"
 

--- a/include/statistics.h
+++ b/include/statistics.h
@@ -1,7 +1,7 @@
 #ifndef STATISTICS_H_
 #define STATISTICS_H_
 
-#include "aux.h"
+#include "helpers.h"
 #include "bencode.h"
 #include "rtpengine_config.h"
 

--- a/include/t38.h
+++ b/include/t38.h
@@ -40,7 +40,7 @@ struct t38_options {
 #include <spandsp/t38_gateway.h>
 
 #include "rtplib.h"
-#include "aux.h"
+#include "helpers.h"
 #include "obj.h"
 #include "codeclib.h"
 

--- a/include/tcp_listener.h
+++ b/include/tcp_listener.h
@@ -3,7 +3,7 @@
 
 #include "socket.h"
 #include "obj.h"
-#include "aux.h"
+#include "helpers.h"
 
 
 struct poller;

--- a/lib/mix_buffer.h
+++ b/lib/mix_buffer.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "aux.h"
+#include "helpers.h"
 
 
 enum AVSampleFormat;

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -13,7 +13,6 @@ rtplib.c
 str.c
 crypto.c
 aes-crypt
-aux.c
 bencode.c
 call.c
 call_interfaces.c
@@ -23,6 +22,7 @@ control_ng.c
 cookie_cache.c
 dtls.c
 graphite.c
+helpers.c
 homer.c
 ice.c
 iptables.c

--- a/t/Makefile
+++ b/t/Makefile
@@ -65,7 +65,7 @@ endif
 
 SRCS=		test-bitstr.c aes-crypt.c aead-aes-crypt.c test-const_str_hash.strhash.c
 LIBSRCS=	loglib.c auxlib.c str.c rtplib.c ssllib.c mix_buffer.c
-DAEMONSRCS=	crypto.c ssrc.c aux.c rtp.c
+DAEMONSRCS=	crypto.c ssrc.c helpers.c rtp.c
 HASHSRCS=
 
 ifeq ($(with_transcoding),yes)
@@ -258,7 +258,7 @@ daemon-tests-audio-player-play-media:	daemon-test-deps
 
 test-bitstr:	test-bitstr.o
 
-test-mix-buffer:	test-mix-buffer.o $(COMMONOBJS) mix_buffer.o ssrc.o rtp.o crypto.o aux.o
+test-mix-buffer:	test-mix-buffer.o $(COMMONOBJS) mix_buffer.o ssrc.o rtp.o crypto.o helpers.o
 
 spandsp_send_fax_pcm:	spandsp_send_fax_pcm.o
 
@@ -280,7 +280,7 @@ aes-crypt:	aes-crypt.o $(COMMONOBJS) crypto.o
 
 aead-aes-crypt:	aead-aes-crypt.o $(COMMONOBJS) crypto.o
 
-test-stats:	test-stats.o $(COMMONOBJS) codeclib.strhash.o resample.o codec.o ssrc.o call.o ice.o aux.o \
+test-stats:	test-stats.o $(COMMONOBJS) codeclib.strhash.o resample.o codec.o ssrc.o call.o ice.o helpers.o \
 	kernel.o media_socket.o stun.o bencode.o socket.o poller.o dtls.o recording.o statistics.o \
 	rtcp.o redis.o iptables.o graphite.o call_interfaces.strhash.o sdp.strhash.o rtp.o crypto.o \
 	control_ng.strhash.o graphite.o \
@@ -288,7 +288,7 @@ test-stats:	test-stats.o $(COMMONOBJS) codeclib.strhash.o resample.o codec.o ssr
 	media_player.o jitter_buffer.o dtmflib.o t38.o tcp_listener.o mqtt.o janus.strhash.o \
 	websocket.o cli.o mvr2s_x64_avx2.o mvr2s_x64_avx512.o audio_player.o mix_buffer.o
 
-test-transcode:	test-transcode.o $(COMMONOBJS) codeclib.strhash.o resample.o codec.o ssrc.o call.o ice.o aux.o \
+test-transcode:	test-transcode.o $(COMMONOBJS) codeclib.strhash.o resample.o codec.o ssrc.o call.o ice.o helpers.o \
 	kernel.o media_socket.o stun.o bencode.o socket.o poller.o dtls.o recording.o statistics.o \
 	rtcp.o redis.o iptables.o graphite.o call_interfaces.strhash.o sdp.strhash.o rtp.o crypto.o \
 	control_ng.strhash.o \
@@ -299,7 +299,7 @@ test-transcode:	test-transcode.o $(COMMONOBJS) codeclib.strhash.o resample.o cod
 test-resample:	test-resample.o $(COMMONOBJS) codeclib.strhash.o resample.o dtmflib.o mvr2s_x64_avx2.o \
 	mvr2s_x64_avx512.o
 
-test-payload-tracker: test-payload-tracker.o $(COMMONOBJS) ssrc.o aux.o auxlib.o rtp.o crypto.o codeclib.strhash.o \
+test-payload-tracker: test-payload-tracker.o $(COMMONOBJS) ssrc.o helpers.o auxlib.o rtp.o crypto.o codeclib.strhash.o \
 	resample.o dtmflib.o mvr2s_x64_avx2.o mvr2s_x64_avx512.o
 
 test-kernel-module: test-kernel-module.o $(COMMONOBJS) kernel.o

--- a/t/log_funcs.h
+++ b/t/log_funcs.h
@@ -1,7 +1,7 @@
 #ifndef _LOG_FUNCS_H_
 #define _LOG_FUNCS_H_
 
-#include "aux.h"
+#include "helpers.h"
 #include "str.h"
 
 struct call;

--- a/t/test-transcode.c
+++ b/t/test-transcode.c
@@ -4,7 +4,7 @@
 #include "log.h"
 #include "main.h"
 #include "ssrc.h"
-#include "aux.h"
+#include "helpers.h"
 
 int _log_facility_rtcp;
 int _log_facility_cdr;


### PR DESCRIPTION
Windows doesn't allow a file to be named aux, so checkout fails.