### PR TITLE
Support dtmf injection when also using delay buffer

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2584,7 +2584,8 @@ void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, ui
 
 	// add to queue if we're doing PCM -> DTMF event conversion
 	// this does not capture events when doing DTMF delay (dtmf_payload_type == -1)
-	if (ch->handler->dtmf_payload_type != -1) {
+	// unless this is an injected event, in which case we check the real payload type
+	if (ch->handler->dtmf_payload_type != -1 || (injected && ch->handler->real_dtmf_payload_type != -1)) {
 		struct dtmf_event *ev = g_slice_alloc(sizeof(*ev));
 		*ev = new_ev;
 		g_queue_push_tail(&ch->dtmf_events, ev);


### PR DESCRIPTION
previously, dtmf_inject wouldn't add the events as the dtmf_payload_type was set to -1 as part of the delay buffer handling. However, as we know we want this DTMF, this change updates the function to check for and use the real_dtmf_payload_type value

Then, in codec_add_dtmf_event, we can check the injected bool and if set, use the real_dtmf_payload_type again to decide whether to push the event onto the queue