### PR TITLE
Build: allow EXTRA_CFLAGS, e.g., -fPIE (needed by EL8/GCC 8.5)

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -6,6 +6,7 @@ with_transcoding ?= yes
 
 CFLAGS?=	-g -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes -Werror=return-type \
 		-Wshadow
+CFLAGS+=	$(EXTRA_CFLAGS)
 CFLAGS+=	-pthread -fno-strict-aliasing
 CFLAGS+=	-std=c11
 CFLAGS+=	$(shell pkg-config --cflags glib-2.0)

--- a/recording-daemon/Makefile
+++ b/recording-daemon/Makefile
@@ -2,6 +2,7 @@ TARGET=		rtpengine-recording
 
 CFLAGS?=	-g -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes -Werror=return-type \
 		-Wshadow
+CFLAGS+=	$(EXTRA_CFLAGS)
 CFLAGS+=	-pthread -I. -I../lib/ -I../kernel-module/
 CFLAGS+=	-std=c11 -fno-strict-aliasing
 CFLAGS+=	-D_GNU_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE


### PR DESCRIPTION
EL8/GCC 8.5 needs `-fPIE` on building `daemon/` on master, mr12.0.1. This PR allows make to receive distro-specific flags.

```
# build with distro specific flags
EXTRA_CFLAGS=-fPIE make 
```

Reason for this PR: error on EL8 on current master without `-fPIE`:
```
/usr/bin/ld: dynamic STT_GNU_IFUNC symbol `s16_mix_in.lto_priv.206' with pointer equality in `/tmp/cceywfR9.ltrans1.ltrans.o' can not be used when making an executable; recompile with -fPIE and relink with -pie
collect2: error: ld returned 1 exit status
```

On EL8 this error is specific to the system GCC 8.5; `-fPIE` is not needed with gcc-toolset-[9-12].