### PR TITLE
RPM packaging: update for EL8/EL9

### DIFF
--- a/el/build-with-mock.sh
+++ b/el/build-with-mock.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+# Sample build script to package RPM using mock
+# Usage: el/build-with-mock.sh <package-version> <git-commit>
+#
+#  el/build-with-mock.sh 12.1.0.0+0~mr12.1.0.0 master
+
+
+set -e
+
+if [[ -z $1 || -z $2 ]]; then
+    echo $0: Require package version and git commit
+    echo "Usage: build-with-mock.sh <version> <commit>"
+    exit 1
+fi
+
+RTPENGINE_VERSION=$1
+GIT_COMMIT=$2
+
+mkdir -p rpmbuild/{SOURCES,SPECS}
+
+git archive --format=tar --prefix=ngcp-rtpengine-${RTPENGINE_VERSION}/ $2 | gzip -c > rpmbuild/SOURCES/ngcp-rtpengine-${RTPENGINE_VERSION}.tar.gz
+
+
+sed /^Version/s"/^Version:.*/Version: ${RTPENGINE_VERSION}/" el/rtpengine.spec > rpmbuild/SPECS/rtpengine.spec
+
+rm -f rpmbuild/SRPMS/*.src.rpm
+rpmbuild --define "_topdir $PWD/rpmbuild" -bs rpmbuild/SPECS/rtpengine.spec
+
+echo  =======================================
+echo "You may now build for EL8/EL9"
+
+
+echo "EL8: mock -r el/rtpengine-8-x86_64.cfg $(ls rpmbuild/SRPMS/*.src.rpm)"
+echo "EL9: mock -r el/rtpengine-9-x86_64.cfg $(ls rpmbuild/SRPMS/*.src.rpm)"
+echo  =======================================

--- a/el/rtpengine-8-x86_64.cfg
+++ b/el/rtpengine-8-x86_64.cfg
@@ -1,0 +1,35 @@
+include('templates/almalinux-8.tpl')
+include('templates/epel-8.tpl')
+
+config_opts['dnf.conf'] += """
+
+[rpmfusion-free-updates]
+name=RPM Fusion for EL $releasever - Free - Updates
+#baseurl=https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=free-el-updates-released-$releasever&arch=$basearch
+enabled=1
+
+[rpmfusion-nonfree-updates]
+name=RPM Fusion for EL $releasever - Nonfree - Updates
+#baseurl=https://download1.rpmfusion.org/nonfree/el/updates/$releasever/$basearch/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-updates-released-$releasever&arch=$basearch
+enabled=1
+
+[copr:copr.fedorainfracloud.org:beaveryoga:broadvoice]
+name=Copr repo for broadvoice owned by beaveryoga
+baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-8-$basearch/
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+"""
+
+config_opts['chroot_additional_packages'] = "perl-interpreter libdb-devel gdbm-devel libuuid-devel speexdsp-devel"
+config_opts['chroot_additional_packages'] += " spandsp3-devel perl-podlators pandoc"
+
+config_opts['root'] = 'rtpengine-8-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+

--- a/el/rtpengine-9-x86_64.cfg
+++ b/el/rtpengine-9-x86_64.cfg
@@ -1,0 +1,36 @@
+include('templates/almalinux-9.tpl')
+include('templates/epel-9.tpl')
+
+config_opts['dnf.conf'] += """
+
+[rpmfusion-free-updates]
+name=RPM Fusion for EL $releasever - Free - Updates
+#baseurl=https://download1.rpmfusion.org/free/el/updates/$releasever/$basearch/
+metalink=https://mirrors.rpmfusion.org/metalink?repo=free-el-updates-released-$releasever&arch=$basearch
+enabled=1
+
+[rpmfusion-nonfree-updates]
+name=RPM Fusion for EL $releasever - Nonfree - Updates
+baseurl=https://download1.rpmfusion.org/nonfree/el/updates/$releasever/$basearch/
+#metalink=https://mirrors.rpmfusion.org/metalink?repo=nonfree-el-updates-released-$releasever&arch=$basearch
+enabled=1
+
+[copr:copr.fedorainfracloud.org:beaveryoga:broadvoice]
+name=Copr repo for broadvoice owned by beaveryoga
+baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-8-$basearch/
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+"""
+
+config_opts['chroot_additional_packages'] = "perl-interpreter libdb-devel gdbm-devel libuuid-devel speexdsp-devel"
+config_opts['chroot_additional_packages'] += " spandsp3-devel perl-podlators pandoc"
+config_opts['chroot_additional_packages'] += " gcc make autoconf automake gcc-c++ libtool"
+
+config_opts['root'] = 'rtpengine-9-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+


### PR DESCRIPTION
Update RPM packaging for EL8/EL9
- add example mock chroots
- update for nftables, iptables deprecation in EL9
- EL8: use newer GCC