### PR TITLE
reuse the master key for SRTP when DTLS restarts

### DIFF
--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -912,10 +912,7 @@ void dtls_shutdown(struct packet_stream *ps) {
 		}
 
 		dtls_connection_cleanup(d);
-
-		crypto_reset(&sfd->crypto);
 	}
-
 
 	if (ps->dtls_cert) {
 		X509_free(ps->dtls_cert);

--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -884,7 +884,6 @@ int dtls(struct stream_fd *sfd, const str *s, const endpoint_t *fsin) {
 
 /* call must be locked */
 void dtls_shutdown(struct packet_stream *ps) {
-
 	if (!ps)
 		return;
 
@@ -924,7 +923,7 @@ void dtls_shutdown(struct packet_stream *ps) {
 	}
 
 	if (had_dtls)
-		call_stream_crypto_reset(ps);
+		ilogs(crypto, LOG_DEBUG, "Reuse SRTP crypto key");
 }
 
 void dtls_connection_cleanup(struct dtls_connection *c) {


### PR DESCRIPTION
Call setup:
1. WebRTC client (DTLS-SRTP)
2. Kam + RTPEngine latest
3. RTPEngine decrypt and send to Asterisk over SIP + RTP/RTCP
4. WebRTC client change IP address during the call
5. Client restart ICE and send renegotiate (new handshake DTLS and Re-INVITE)
6. The master key (SRTP) remains the same (on Chrome, Firefox, Safari)
7. WebRTC client send SRTP to RTPEngine with same master key for SRTP
8. RTPEngine have issue with  encrypt and decrypt this S/RTP (from WebRTC and from Asterisk)

Issue is in the RTPEngine, when restart DTLS make clean Master key for SRTP.
This behaviour has been addressed here in Chromium https://bugs.chromium.org/p/webrtc/issues/detail?id=5205
I attached fix.