### PR TITLE
Fixing Source and Destination fields in pcap when record-egress is enabled

### DIFF
--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -16,6 +16,7 @@
 #include "xt_RTPENGINE.h"
 
 #include "call.h"
+#include "main.h"
 #include "kernel.h"
 #include "bencode.h"
 #include "rtplib.h"
@@ -646,8 +647,15 @@ static void rec_pcap_recording_finish_file(struct recording *recording) {
 
 // "out" must be at least inp->len + MAX_PACKET_HEADER_LEN bytes
 static unsigned int fake_ip_header(unsigned char *out, struct media_packet *mp, const str *inp) {
-	endpoint_t *src_endpoint = &mp->fsin;
-	endpoint_t *dst_endpoint = &mp->sfd->socket.local;
+	endpoint_t *src_endpoint, *dst_endpoint;
+        if (!rtpe_config.rec_egress) {
+                src_endpoint = &mp->fsin;
+                dst_endpoint = &mp->sfd->socket.local;
+        }
+        else {
+                src_endpoint = &mp->sfd->socket.local;
+                dst_endpoint = &mp->fsin;
+        }
 
 	unsigned int hdr_len =
 		endpoint_packet_header(out, src_endpoint, dst_endpoint, inp->len);


### PR DESCRIPTION
Sorce and Destinations fields in pcap are not proper when record-egress is enabled.
For example consider the below scenario:

A Leg:
	User A : X.X.X.X:6000
	RtpEngine : Z.Z.Z.Z:10002

B Leg:
	User B: Y.Y.Y.Y:6004
	RtpEngine: Z.Z.Z.Z:10016


When Media starts flowing from A to B through RtpEngine and with record-egress enabled, the source and destination fields in pcap are Source: "Y.Y.Y.Y:6004" and "Destination: Z.Z.Z.Z:10016” which is incorrect. It should be the other way around 
i.e "Source: Z.Z.Z.Z:10016" and "Destination: Y.Y.Y.Y:6004”  as we are capturing the outgoing packets from Rtpengine to User B.