### PR TITLE
Adding support for NG trace to Homer

### DIFF
--- a/daemon/control_udp.c
+++ b/daemon/control_udp.c
@@ -26,7 +26,8 @@ static void control_udp_incoming(struct obj *obj, struct udp_buffer *udp_buf) {
 	char **out;
 	struct iovec iov[10];
 	unsigned int iovlen;
-	str cookie, *reply;
+	str cookie, *reply = NULL;
+	cache_entry *ce;
 
 	pcre2_match_data *md = pcre2_match_data_create(30, NULL);
 	ret = pcre2_match(u->parse_re, (PCRE2_SPTR8) udp_buf->str.s, udp_buf->str.len, 0, 0, md, NULL);
@@ -71,11 +72,12 @@ static void control_udp_incoming(struct obj *obj, struct udp_buffer *udp_buf) {
 	pcre2_substring_list_get(md, (PCRE2_UCHAR ***) &out, NULL);
 
 	str_init(&cookie, (void *) out[RE_UDP_COOKIE]);
-	reply = cookie_cache_lookup(&u->cookie_cache, &cookie);
-	if (reply) {
+	ce = cookie_cache_lookup(&u->cookie_cache, &cookie);
+	if (ce) {
+		reply = ce->reply;
 		ilogs(control, LOG_INFO, "Detected command from udp:%s as a duplicate", udp_buf->addr);
 		socket_sendto_from(udp_buf->listener, reply->s, reply->len, &udp_buf->sin, &udp_buf->local_addr);
-		free(reply);
+		cache_entry_free(ce);
 		goto out;
 	}
 
@@ -122,7 +124,10 @@ static void control_udp_incoming(struct obj *obj, struct udp_buffer *udp_buf) {
 
 	if (reply) {
 		socket_sendto_from(udp_buf->listener, reply->s, reply->len, &udp_buf->sin, &udp_buf->local_addr);
-		cookie_cache_insert(&u->cookie_cache, &cookie, reply);
+
+		str callid = STR_NULL;
+		cache_entry new_ce = {.reply = reply, .callid = &callid};
+		cookie_cache_insert(&u->cookie_cache, &cookie, &new_ce);
 		free(reply);
 	}
 	else

--- a/daemon/homer.c
+++ b/daemon/homer.c
@@ -41,7 +41,7 @@ static struct homer_sender *main_homer_sender;
 
 
 static int send_hepv3 (GString *s, const str *id, int, const endpoint_t *src, const endpoint_t *dst,
-		const struct timeval *);
+		const struct timeval *, int hep_capture_proto);
 
 // state handlers
 static int __established(struct homer_sender *hs);
@@ -203,7 +203,7 @@ void homer_sender_init(const endpoint_t *ep, int protocol, int capture_id) {
 
 // takes over the GString
 int homer_send(GString *s, const str *id, const endpoint_t *src,
-		const endpoint_t *dst, const struct timeval *tv)
+		const endpoint_t *dst, const struct timeval *tv, int hep_capture_proto)
 {
 	if (!main_homer_sender)
 		goto out;
@@ -214,7 +214,7 @@ int homer_send(GString *s, const str *id, const endpoint_t *src,
 
 	ilog(LOG_DEBUG, "JSON to send to Homer: '"STR_FORMAT"'", G_STR_FMT(s));
 
-	if (send_hepv3(s, id, main_homer_sender->capture_id, src, dst, tv))
+	if (send_hepv3(s, id, main_homer_sender->capture_id, src, dst, tv, hep_capture_proto))
 		goto out;
 
 	mutex_lock(&main_homer_sender->lock);
@@ -318,11 +318,9 @@ struct hep_generic {
 
 typedef struct hep_generic hep_generic_t;
 
-#define PROTO_RTCP_JSON   0x05
-
 // modifies the GString in place
 static int send_hepv3 (GString *s, const str *id, int capt_id, const endpoint_t *src, const endpoint_t *dst,
-		const struct timeval *tv)
+		const struct timeval *tv, int hep_capture_proto)
 {
 
     struct hep_generic *hg=NULL;
@@ -417,7 +415,7 @@ static int send_hepv3 (GString *s, const str *id, int capt_id, const endpoint_t 
     /* Protocol TYPE */
     hg->proto_t.chunk.vendor_id = htons(0x0000);
     hg->proto_t.chunk.type_id   = htons(0x000b);
-    hg->proto_t.data = PROTO_RTCP_JSON;
+    hg->proto_t.data = hep_capture_proto;
     hg->proto_t.chunk.length = htons(sizeof(hg->proto_t));
 
     /* Capture ID */

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -86,6 +86,7 @@ struct rtpengine_config rtpe_config = {
 	.interfaces = G_QUEUE_INIT,
 	.homer_protocol = SOCK_DGRAM,
 	.homer_id = 2001,
+	.homer_ng_capt_proto = 0x3d, // first available value in HEP proto specification
 	.port_min = 30000,
 	.port_max = 40000,
 	.redis_db = -1,
@@ -578,6 +579,9 @@ static void options(int *argc, char ***argv) {
 		{ "homer",	0,  0, G_OPTION_ARG_STRING,	&homerp,	"Address of Homer server for RTCP stats","IP46|HOSTNAME:PORT"},
 		{ "homer-protocol",0,0,G_OPTION_ARG_STRING,	&homerproto,	"Transport protocol for Homer (default udp)",	"udp|tcp"	},
 		{ "homer-id",	0,  0, G_OPTION_ARG_INT,	&rtpe_config.homer_id,	"'Capture ID' to use within the HEP protocol", "INT"	},
+		{ "homer-disable-rtcp-stats", 0, 0, G_OPTION_ARG_NONE,	&rtpe_config.homer_rtcp_off,	"Disable RTCP stats tracing to Homer (enabled by default if homer server enabled)", NULL	},
+		{ "homer-enable-ng", 0, 0, G_OPTION_ARG_NONE,	&rtpe_config.homer_ng_on,	"Enable NG tracing to Homer", NULL	},
+		{ "homer-ng-capture-proto", 0, 0, G_OPTION_ARG_INT,	&rtpe_config.homer_ng_capt_proto,	"'Capture protocol type' to use within the HEP protocol (default is 0x3d). Further used by the Homer capture and UI.", "UINT8"	},
 		{ "recording-dir", 0, 0, G_OPTION_ARG_STRING,	&rtpe_config.spooldir,	"Directory for storing pcap and metadata files", "FILE"	},
 		{ "recording-method",0, 0, G_OPTION_ARG_STRING,	&rtpe_config.rec_method,	"Strategy for call recording",		"pcap|proc|all"	},
 		{ "recording-format",0, 0, G_OPTION_ARG_STRING,	&rtpe_config.rec_format,	"File format for stored pcap files",	"raw|eth"	},
@@ -797,6 +801,9 @@ static void options(int *argc, char ***argv) {
 		else
 			die("Invalid protocol '%s' (--homer-protocol)", homerproto);
 	}
+
+	if (rtpe_config.homer_ng_capt_proto <0 || rtpe_config.homer_ng_capt_proto > 255)
+		die("Invalid homer-ng-capture-proto value");
 
 	if (rtpe_config.default_tos < 0 || rtpe_config.default_tos > 255)
 		die("Invalid TOS value");
@@ -1091,6 +1098,7 @@ static void fill_initial_rtpe_cfg(struct rtpengine_config* ini_rtpe_cfg) {
 	ini_rtpe_cfg->redis_num_threads = rtpe_config.redis_num_threads;
 	ini_rtpe_cfg->homer_protocol = rtpe_config.homer_protocol;
 	ini_rtpe_cfg->homer_id = rtpe_config.homer_id;
+	ini_rtpe_cfg->homer_ng_capt_proto = rtpe_config.homer_ng_capt_proto;
 	ini_rtpe_cfg->no_fallback = rtpe_config.no_fallback;
 	ini_rtpe_cfg->port_min = rtpe_config.port_min;
 	ini_rtpe_cfg->port_max = rtpe_config.port_max;
@@ -1329,6 +1337,7 @@ static void create_everything(void) {
 	homer_sender_init(&rtpe_config.homer_ep, rtpe_config.homer_protocol, rtpe_config.homer_id);
 
 	rtcp_init(); // must come after Homer init
+	init_ng_tracing(); // must come after Homer init
 
 	gettimeofday(&rtpe_latest_graphite_interval_start, NULL);
 

--- a/daemon/rtcp.c
+++ b/daemon/rtcp.c
@@ -1132,7 +1132,7 @@ static void homer_finish(struct rtcp_process_ctx *ctx, call_t *c, const endpoint
 	str_sanitize(ctx->json);
 	g_string_append(ctx->json, " }");
 	if (ctx->json->len > ctx->json_init_len + 2)
-		homer_send(ctx->json, &c->callid, src, dst, tv);
+		homer_send(ctx->json, &c->callid, src, dst, tv, PROTO_RTCP_JSON);
 	else
 		g_string_free(ctx->json, TRUE);
 	ctx->json = NULL;
@@ -1407,7 +1407,7 @@ static void transcode_sr_wrap(struct rtcp_process_ctx *ctx, struct sender_report
 
 void rtcp_init(void) {
 	rtcp_handlers.logging = _log_facility_rtcp ? &log_handlers : &dummy_handlers;
-	rtcp_handlers.homer = has_homer() ? &homer_handlers : &dummy_handlers;
+	rtcp_handlers.homer = has_homer() && !rtpe_config.homer_rtcp_off ? &homer_handlers : &dummy_handlers;
 }
 
 

--- a/docs/rtpengine.md
+++ b/docs/rtpengine.md
@@ -652,6 +652,8 @@ call to inject-DTMF won't be sent to __\-\-dtmf-log-dest=__ or __\-\-listen-tcp-
     capture server.
     The transport is HEP version 3 and payload format is JSON.
     This argument takes an IP address and a port number as value.
+    Also enables sending the control NG traffic to a capturing agent.
+    Payload format does not apply in this case.
 
 - __\-\-homer-protocol=udp__\|__tcp__
 
@@ -662,6 +664,25 @@ call to inject-DTMF won't be sent to __\-\-dtmf-log-dest=__ or __\-\-listen-tcp-
     The HEP protocol used by Homer contains a "capture ID" used to distinguish
     different sources of capture data.
     This ID can be specified using this argument.
+
+- __\-\-homer-disable-rtcp-stats__
+
+    Disables the default behaviour that RTCP stats are sent when homer
+    parameter is set. Sending of RTCP and NG are as such decoupled.
+
+- __\-\-homer-enable-ng__
+
+    Enables sending control NG packages to a Homer capturing software. The
+    capturing agent part is not officialy supported OOTB, but it can be
+    achieved with Kamailio by using the config. For this feature to work one
+    has to set at least the homer parameter.
+
+- __\-\-homer-ng-capture-proto=__*INT*
+
+    The HEP protocol used by Homer contains a "Capture protocol type" UINT8
+    used by the capturing agent and UI to make further processing. Some values
+    are registered, but currently 0x3d values onwards are free.
+    Default value is 0x3d (61).
 
 - __\-\-recording-dir=__*FILE*
 
@@ -1151,9 +1172,9 @@ call to inject-DTMF won't be sent to __\-\-dtmf-log-dest=__ or __\-\-listen-tcp-
 - __\-\-dtls-mtu=__*INT*
 
     Set DTLS MTU to enable fragmenting of large DTLS packets. Defaults to 1200.
-    Minimum value is 576 as the internet protocol requires that hosts must be able to 
+    Minimum value is 576 as the internet protocol requires that hosts must be able to
     process IP datagrams of at least 576 bytes (for IPv4) or 1280 bytes (for IPv6).
-    This does not preclude link layers with an MTU smaller than this minimum MTU from 
+    This does not preclude link layers with an MTU smaller than this minimum MTU from
     conveying IP data. Internet IPv4 path MTU is 68 bytes.
 
 - __\-\-mqtt-host=__*HOST*\|*IP*

--- a/include/control_ng.h
+++ b/include/control_ng.h
@@ -76,6 +76,7 @@ int control_ng_process(str *buf, const endpoint_t *sin, char *addr, const sockad
 		void (*cb)(str *, str *, const endpoint_t *, const sockaddr_t *, void *), void *p1, struct obj *);
 int control_ng_process_plain(str *buf, const endpoint_t *sin, char *addr, const sockaddr_t *local,
 		void (*cb)(str *, str *, const endpoint_t *, const sockaddr_t *, void *), void *p1, struct obj *);
+void init_ng_tracing(void);
 
 ng_buffer *ng_buffer_new(struct obj *ref);
 

--- a/include/cookie_cache.h
+++ b/include/cookie_cache.h
@@ -12,6 +12,30 @@ struct cookie_cache_state {
 	GHashTable *cookies;
 };
 
+typedef struct cache_entry {
+	str *reply;
+	str *callid;
+	int command;
+} cache_entry;
+
+INLINE cache_entry *cache_entry_dup(const cache_entry *s) {
+	if (!s)
+		return NULL;
+	cache_entry *r;
+	r = malloc(sizeof(*r));
+	r->reply = str_dup(s->reply);
+	r->command = s->command;
+	r->callid = str_dup(s->callid);
+	return r;
+}
+INLINE void cache_entry_free(void *p) {
+	cache_entry *s = p;
+	if (!s)
+		return;
+	free(s->reply);
+	free(s->callid);
+	free(s);
+}
 struct cookie_cache {
 	mutex_t lock;
 	cond_t cond;
@@ -20,8 +44,8 @@ struct cookie_cache {
 };
 
 void cookie_cache_init(struct cookie_cache *);
-str *cookie_cache_lookup(struct cookie_cache *, const str *);
-void cookie_cache_insert(struct cookie_cache *, const str *, const str *);
+cache_entry *cookie_cache_lookup(struct cookie_cache *, const str *);
+void cookie_cache_insert(struct cookie_cache *, const str *, const struct cache_entry *);
 void cookie_cache_remove(struct cookie_cache *, const str *);
 void cookie_cache_cleanup(struct cookie_cache *);
 

--- a/include/homer.h
+++ b/include/homer.h
@@ -3,9 +3,11 @@
 
 #include "socket.h"
 
+#define PROTO_RTCP_JSON     0x05
+
 void homer_sender_init(const endpoint_t *, int, int);
 int homer_send(GString *, const str *, const endpoint_t *, const endpoint_t *,
-		const struct timeval *tv);
+		const struct timeval *, int);
 int has_homer(void);
 
 #endif

--- a/include/main.h
+++ b/include/main.h
@@ -71,6 +71,9 @@ struct rtpengine_config {
 	endpoint_t		homer_ep;
 	int			homer_protocol;
 	int			homer_id;
+	int			homer_ng_capt_proto;
+	gboolean		homer_rtcp_off;
+	gboolean		homer_ng_on;
 	gboolean		no_fallback;
 	gboolean		reject_invalid_sdp;
 	gboolean		save_interface_ports;


### PR DESCRIPTION
Proposing a patch to also send NG traffic to sipcapture servers.

For a sipcapture server one can use Kamailio and insert from the config similar to https://github.com/sipcapture/homer-config/blob/master/sipcapture/sipcapture.kamailio5. 

I am setting the protocol type to 0x3d (61) - rtcp homer fills it with 0x05.

Support is desired for Kamailio/Rtpengine traffic via UDP. Adding homer-enable-rtcp-stats and homer-enable-ng config params to separately control sending to Homer each traffic type. By default rtcp is `on` when homer parameter is configured. NG is by default `off`.

Any comments are appreciated,
Thank you