### PR TITLE
Add output-mixed-per-media

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2864,6 +2864,8 @@ int monologue_offer_answer(struct call_monologue *monologues[2], sdp_streams_q *
 		 * the dialogue */
 		media = __get_media(monologue, sp, flags, 0);
 		other_media = __get_media(other_ml, sp, flags, 0);
+		media->label = sp->label;
+		other_media->label = sp->label;
 		/* OTHER is the side which has sent the message. SDP parameters in
 		 * "sp" are as advertised by OTHER side. The message will be sent to
 		 * THIS side. Parameters sent to THIS side may be overridden by

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2864,8 +2864,9 @@ int monologue_offer_answer(struct call_monologue *monologues[2], sdp_streams_q *
 		 * the dialogue */
 		media = __get_media(monologue, sp, flags, 0);
 		other_media = __get_media(other_ml, sp, flags, 0);
-		media->label = sp->label;
-		other_media->label = sp->label;
+		media->media_sdp_id = sp->media_sdp_id;
+		other_media->media_sdp_id = sp->media_sdp_id;
+
 		/* OTHER is the side which has sent the message. SDP parameters in
 		 * "sp" are as advertised by OTHER side. The message will be sent to
 		 * THIS side. Parameters sent to THIS side may be overridden by

--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -946,9 +946,9 @@ static void setup_stream_proc(struct packet_stream *stream) {
 	if (ML_ISSET(ml, NO_RECORDING))
 		return;
 
-	len = snprintf(buf, sizeof(buf), "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64,
-			ml->unique_id, media->unique_id, media->index, stream->component,
-			atomic64_get_na(&stream->ps_flags));
+	len = snprintf(buf, sizeof(buf), "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-SDP-ID %i",
+				   ml->unique_id, media->unique_id, media->index, stream->component,
+				   atomic64_get_na(&stream->ps_flags), media->media_sdp_id);
 	append_meta_chunk(recording, buf, len, "STREAM %u details", stream->unique_id);
 
 	len = snprintf(buf, sizeof(buf), "tag-%u-media-%u-component-%u-%s-id-%u",
@@ -962,9 +962,6 @@ static void setup_stream_proc(struct packet_stream *stream) {
 	}
 	ilog(LOG_DEBUG, "kernel stream idx is %u", stream->recording.proc.stream_idx);
 	append_meta_chunk(recording, buf, len, "STREAM %u interface", stream->unique_id);
-	if (media->label.len){
-		append_meta_chunk(recording, media->label.s, media->label.len, "STREAM %u sdplabel", stream->unique_id);
-	}
 }
 
 static void setup_monologue_proc(struct call_monologue *ml) {

--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -962,6 +962,9 @@ static void setup_stream_proc(struct packet_stream *stream) {
 	}
 	ilog(LOG_DEBUG, "kernel stream idx is %u", stream->recording.proc.stream_idx);
 	append_meta_chunk(recording, buf, len, "STREAM %u interface", stream->unique_id);
+	if (media->label.len){
+		append_meta_chunk(recording, media->label.s, media->label.len, "STREAM %u sdplabel", stream->unique_id);
+	}
 }
 
 static void setup_monologue_proc(struct call_monologue *ml) {

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -1926,6 +1926,12 @@ int sdp_streams(const sdp_sessions_q *sessions, sdp_streams_q *streams, sdp_ng_f
 			if (attr)
 				sp->media_id = attr->strs.value;
 
+			// a=label
+			attr = attr_get_by_id(&media->attributes, ATTR_LABEL);
+			if (attr){
+				sp->label = attr->strs.value;
+			}
+
 			// be ignorant about the contents
 			if (attr_get_by_id(&media->attributes, ATTR_RTCP_FB))
 				SP_SET(sp, RTCP_FB);

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -137,6 +137,8 @@ struct sdp_media {
 	struct sdp_attributes attributes;
 	GQueue format_list; /* list of slice-alloc'd str objects */
 	enum media_type media_type_id;
+	int media_sdp_id;
+
 
 	unsigned int legacy_osrtp:1;
 };
@@ -1252,6 +1254,7 @@ int sdp_parse(str *body, sdp_sessions_q *sessions, const sdp_ng_flags *flags) {
 	struct sdp_attributes *attrs;
 	struct sdp_attribute *attr;
 	str *adj_s;
+	int media_sdp_id = 0;
 
 	b = body->s;
 	end = str_end(body);
@@ -1332,7 +1335,7 @@ new_session:
 				t_queue_push_tail(&session->media_streams, media);
 				media->s.s = b;
 				media->rr = media->rs = -1;
-
+				media->media_sdp_id = media_sdp_id++;
 				break;
 
 			case 'c':
@@ -1810,6 +1813,7 @@ int sdp_streams(const sdp_sessions_q *sessions, sdp_streams_q *streams, sdp_ng_f
 			sp = g_slice_alloc0(sizeof(*sp));
 			sp->index = ++num;
 			codec_store_init(&sp->codecs, NULL);
+			sp->media_sdp_id = media->media_sdp_id;
 
 			errstr = "No address info found for stream";
 			if (!flags->fragment
@@ -1925,12 +1929,6 @@ int sdp_streams(const sdp_sessions_q *sessions, sdp_streams_q *streams, sdp_ng_f
 			attr = attr_get_by_id(&media->attributes, ATTR_MID);
 			if (attr)
 				sp->media_id = attr->strs.value;
-
-			// a=label
-			attr = attr_get_by_id(&media->attributes, ATTR_LABEL);
-			if (attr){
-				sp->label = attr->strs.value;
-			}
 
 			// be ignorant about the contents
 			if (attr_get_by_id(&media->attributes, ATTR_RTCP_FB))

--- a/docs/rtpengine-recording.md
+++ b/docs/rtpengine-recording.md
@@ -355,6 +355,10 @@ sufficient for a standard installation of rtpengine.
     Remove the local file if the HTTP request was successful. Note that this
     option is only useful if __\-\-notify-record__ is also enabled.
 
+- __\-\-output-mixed-per-media__
+
+    Forces one channel per media instead of SSRC. Note that this
+    option is only useful if __\-\-\-\-output-mixed__ is also enabled.
 ## EXIT STATUS
 
 - __0__

--- a/include/call.h
+++ b/include/call.h
@@ -346,7 +346,7 @@ struct stream_params {
 	str			media_id;
 	struct t38_options	t38_options;
 	str			tls_id;
-	str			label;
+	int			media_sdp_id;
 };
 
 struct endpoint_map {
@@ -500,6 +500,7 @@ struct call_media {
 	// lists are append-only
 	dtmf_event_q		dtmf_recv;
 	dtmf_event_q		dtmf_send;
+	int					media_sdp_id;
 
 #ifdef WITH_TRANSCODING
 	encoder_callback_t	encoder_callback;

--- a/include/call.h
+++ b/include/call.h
@@ -346,6 +346,7 @@ struct stream_params {
 	str			media_id;
 	struct t38_options	t38_options;
 	str			tls_id;
+	str			label;
 };
 
 struct endpoint_map {
@@ -499,6 +500,7 @@ struct call_media {
 	// lists are append-only
 	dtmf_event_q		dtmf_recv;
 	dtmf_event_q		dtmf_send;
+	str					label;
 
 #ifdef WITH_TRANSCODING
 	encoder_callback_t	encoder_callback;

--- a/include/call.h
+++ b/include/call.h
@@ -500,7 +500,6 @@ struct call_media {
 	// lists are append-only
 	dtmf_event_q		dtmf_recv;
 	dtmf_event_q		dtmf_send;
-	str					label;
 
 #ifdef WITH_TRANSCODING
 	encoder_callback_t	encoder_callback;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream_media);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->sdp_label)
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->sdp_label);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream_media);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, ssrc->stream->name);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->sdp_label)
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, ssrc->stream->name);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->sdp_label);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media_sdp_id);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -67,6 +67,7 @@ int notify_threads = 5;
 int notify_retries = 10;
 gboolean notify_record;
 gboolean notify_purge;
+gboolean mix_output_per_media = 0;
 
 static GQueue threads = G_QUEUE_INIT; // only accessed from main thread
 
@@ -225,6 +226,7 @@ static void options(int *argc, char ***argv) {
 		{ "notify-no-verify", 	0,   0, G_OPTION_ARG_NONE,	&notify_nverify,"Don't verify HTTPS peer certificate",	NULL		},
 		{ "notify-concurrency",	0,   0, G_OPTION_ARG_INT,	&notify_threads,"How many simultaneous requests",	"INT"		},
 		{ "notify-retries",	0,   0, G_OPTION_ARG_INT,	&notify_retries,"How many times to retry failed requesets","INT"	},
+		{ "output-mixed-per-media", 0, 0, G_OPTION_ARG_NONE, &mix_output_per_media, "Mix participating sources into a single output", "INT"},
 #if CURL_AT_LEAST_VERSION(7,56,0)
 		{ "notify-record", 	0,   0, G_OPTION_ARG_NONE,	&notify_record, "Also attach recorded file to request", NULL		},
 		{ "notify-purge", 	0,   0, G_OPTION_ARG_NONE,	&notify_purge,	"Remove the local file if notify success", NULL		},

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -49,7 +49,7 @@ extern int notify_threads;
 extern int notify_retries;
 extern gboolean notify_record;
 extern gboolean notify_purge;
-
+extern gboolean mix_output_per_media;
 extern volatile int shutdown_flag;
 
 

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -113,6 +113,14 @@ static void meta_stream_details(metafile_t *mf, unsigned long snum, char *conten
 	stream_details(mf, snum, tag, media);
 }
 
+// mf is locked
+static void meta_stream_sdp_label(metafile_t *mf, unsigned long snum, char *content) {
+	dbg("stream %lu sdp label %s", snum, content);
+	unsigned long label;
+	if (sscanf_match(content, "%lu", &label) != 1)
+		return;
+	stream_sdp_label(mf, snum, &label);
+}
 
 // mf is locked
 static void meta_rtp_payload_type(metafile_t *mf, unsigned long mnum, unsigned int payload_num,
@@ -227,6 +235,8 @@ static void meta_section(metafile_t *mf, char *section, char *content, unsigned 
 		meta_stream_interface(mf, lu, content);
 	else if (sscanf_match(section, "STREAM %lu details", &lu) == 1)
 		meta_stream_details(mf, lu, content);
+	else if (sscanf_match(section, "STREAM %lu sdplabel", &lu) == 1)
+		meta_stream_sdp_label(mf, lu, content);
 	else if (sscanf_match(section, "MEDIA %lu PAYLOAD TYPE %u", &lu, &u) == 2)
 		meta_rtp_payload_type(mf, lu, u, content);
 	else if (sscanf_match(section, "MEDIA %lu FMTP %u", &lu, &u) == 2)

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -105,22 +105,14 @@ static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *cont
 // mf is locked
 static void meta_stream_details(metafile_t *mf, unsigned long snum, char *content) {
 	dbg("stream %lu details %s", snum, content);
-	unsigned int tag, media, tm, cmp;
+	unsigned int tag, media, tm, cmp, media_sdp_id;
 	uint64_t flags;
-	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64,
-				&tag, &media, &tm, &cmp, &flags) != 5)
+	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-SDP-ID %i",
+				&tag, &media, &tm, &cmp, &flags, &media_sdp_id) != 6)
 		return;
-	stream_details(mf, snum, tag, media);
+	stream_details(mf, snum, tag, media_sdp_id);
 }
 
-// mf is locked
-static void meta_stream_sdp_label(metafile_t *mf, unsigned long snum, char *content) {
-	dbg("stream %lu sdp label %s", snum, content);
-	unsigned long label;
-	if (sscanf_match(content, "%lu", &label) != 1)
-		return;
-	stream_sdp_label(mf, snum, &label);
-}
 
 // mf is locked
 static void meta_rtp_payload_type(metafile_t *mf, unsigned long mnum, unsigned int payload_num,
@@ -235,8 +227,6 @@ static void meta_section(metafile_t *mf, char *section, char *content, unsigned 
 		meta_stream_interface(mf, lu, content);
 	else if (sscanf_match(section, "STREAM %lu details", &lu) == 1)
 		meta_stream_details(mf, lu, content);
-	else if (sscanf_match(section, "STREAM %lu sdplabel", &lu) == 1)
-		meta_stream_sdp_label(mf, lu, content);
 	else if (sscanf_match(section, "MEDIA %lu PAYLOAD TYPE %u", &lu, &u) == 2)
 		meta_rtp_payload_type(mf, lu, u, content);
 	else if (sscanf_match(section, "MEDIA %lu FMTP %u", &lu, &u) == 2)

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -110,7 +110,7 @@ static void meta_stream_details(metafile_t *mf, unsigned long snum, char *conten
 	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64,
 				&tag, &media, &tm, &cmp, &flags) != 5)
 		return;
-	stream_details(mf, snum, tag);
+	stream_details(mf, snum, tag, media);
 }
 
 

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,7 +83,7 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int *media) {
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
 		next = media - 1;

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -88,7 +88,7 @@ unsigned int mix_get_index(mix_t *mix, void *ptr) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
 		next = ptr->stream->media - 1;
-		if (idx >= mix_num_inputs) {
+		if (next >= mix_num_inputs) {
 			ilog(LOG_WARNING, "Error with mix_output_per_media media next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
 		}
 	}

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,17 +83,10 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int sdp_label) {
-	/////////////////////TODO
-	/////////////////////TODO
-	/////////////////////TODO
-	/////////////////////TODO
-	/////////////////////TODO
-	/////////////////////TODO
-
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media_sdp_id) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
-		next = sdp_label - 1;
+		next = media_sdp_id;
 		if (next >= mix_num_inputs) {
 			ilog(LOG_WARNING, "Error with mix_output_per_media sdp_label next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
 		}
@@ -196,6 +189,8 @@ int mix_config(mix_t *mix, const format_t *format) {
 		err = "failed to link abuffer to amix";
 		if (avfilter_link(mix->src_ctxs[i], 0, mix->amix_ctx, i))
 			goto err;
+
+
 	}
 
 	// sink
@@ -211,6 +206,7 @@ int mix_config(mix_t *mix, const format_t *format) {
 	err = "failed to link amix to abuffersink";
 	if (avfilter_link(mix->amix_ctx, 0, mix->sink_ctx, 0))
 		goto err;
+
 
 	// finish up
 	err = "failed to configure filter chain";

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,8 +83,7 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-
-unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media) {
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int *media) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
 		next = media - 1;

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,25 +83,14 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-unsigned int get_media_id(const char *stream_name) {
-	const char *mediaStr = strstr(stream_name, "media-");
-	if (mediaStr != NULL)
-	{
-		int mediaId;
-		if (sscanf(mediaStr, "media-%d", &mediaId) == 1)
-		{
-			return mediaId;
-		}
-	}
-	return -1; // Return an invalid ID if not found
-}
 
-unsigned int mix_get_index(mix_t *mix, void *ptr, char *name) {
+unsigned int mix_get_index(mix_t *mix, void *ptr) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
-		next = get_media_id(name) - 1;
-		mix->input_ref[next] = ptr;
-		return next;
+		next = ptr->stream->media - 1;
+		if (idx >= mix_num_inputs) {
+			ilog(LOG_WARNING, "Error with mix_output_per_media media next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
+		}
 	}
 
 	if (next < mix_num_inputs) {

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,12 +83,19 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media) {
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int sdp_label) {
+	/////////////////////TODO
+	/////////////////////TODO
+	/////////////////////TODO
+	/////////////////////TODO
+	/////////////////////TODO
+	/////////////////////TODO
+
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
-		next = media - 1;
+		next = sdp_label - 1;
 		if (next >= mix_num_inputs) {
-			ilog(LOG_WARNING, "Error with mix_output_per_media media next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
+			ilog(LOG_WARNING, "Error with mix_output_per_media sdp_label next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
 		}
 	}
 

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -84,10 +84,10 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 
 
 
-unsigned int mix_get_index(mix_t *mix, void *ptr) {
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media) {
 	unsigned int next = mix->next_idx++;
 	if (mix_output_per_media == 1) {
-		next = ptr->stream->media - 1;
+		next = media - 1;
 		if (next >= mix_num_inputs) {
 			ilog(LOG_WARNING, "Error with mix_output_per_media media next %i is bigger than mix_num_inputs %i", next, mix_num_inputs );
 		}

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -83,8 +83,27 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 }
 
 
-unsigned int mix_get_index(mix_t *mix, void *ptr) {
+unsigned int get_media_id(const char *stream_name) {
+	const char *mediaStr = strstr(stream_name, "media-");
+	if (mediaStr != NULL)
+	{
+		int mediaId;
+		if (sscanf(mediaStr, "media-%d", &mediaId) == 1)
+		{
+			return mediaId;
+		}
+	}
+	return -1; // Return an invalid ID if not found
+}
+
+unsigned int mix_get_index(mix_t *mix, void *ptr, char *name) {
 	unsigned int next = mix->next_idx++;
+	if (mix_output_per_media == 1) {
+		next = get_media_id(name) - 1;
+		mix->input_ref[next] = ptr;
+		return next;
+	}
+
 	if (next < mix_num_inputs) {
 		// must be unused
 		mix->input_ref[next] = ptr;

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -10,7 +10,7 @@ mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *, char *);
+unsigned int mix_get_index(mix_t *, void *);
 
 #endif
 

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -10,8 +10,7 @@ mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *);
-
+unsigned int mix_get_index(mix_t *, void *, char *);
 
 #endif
 

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -10,7 +10,6 @@ mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *, unsigned int *);
-
+unsigned int mix_get_index(mix_t *, void *, unsigned int);
 #endif
 

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -10,7 +10,7 @@ mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *);
+unsigned int mix_get_index(mix_t *, void *, unsigned int *);
 
 #endif
 

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -141,6 +141,7 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 void stream_details(metafile_t *mf, unsigned long id, unsigned int tag) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
+	stream_media = media;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -138,20 +138,14 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 	epoll_add(stream->fd, EPOLLIN, &stream->handler);
 }
 
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media) {
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
-	stream->media = media;
+	stream->media_sdp_id = media_sdp_id;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {
 	stream_t *stream = stream_get(mf, id);
 	dbg("Setting forwarding flag to %u for stream #%lu", on, stream->id);
 	stream->forwarding_on = on ? 1 : 0;
-}
-
-void stream_sdp_label(metafile_t *mf, unsigned long id, unsigned long *label) {
-	stream_t *stream = stream_get(mf, id);
-	dbg("Setting sdp label to %lu for stream #%lu", *label, stream->id);
-	stream->sdp_label = *label;
 }

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -149,3 +149,9 @@ void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {
 	dbg("Setting forwarding flag to %u for stream #%lu", on, stream->id);
 	stream->forwarding_on = on ? 1 : 0;
 }
+
+void stream_sdp_label(metafile_t *mf, unsigned long id, unsigned long *label) {
+	stream_t *stream = stream_get(mf, id);
+	dbg("Setting sdp label to %lu for stream #%lu", *label, stream->id);
+	stream->sdp_label = *label;
+}

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -138,7 +138,7 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 	epoll_add(stream->fd, EPOLLIN, &stream->handler);
 }
 
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag) {
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
 	stream_media = media;

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -141,7 +141,7 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
-	stream_media = media;
+	stream->media = media;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 void stream_open(metafile_t *mf, unsigned long id, char *name);
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media);
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
 void stream_sdp_label(metafile_t *mf, unsigned long id, unsigned long *label);
 void stream_close(stream_t *stream);

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 void stream_open(metafile_t *mf, unsigned long id, char *name);
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag);
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
 void stream_close(stream_t *stream);
 void stream_free(stream_t *stream);

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -6,6 +6,7 @@
 void stream_open(metafile_t *mf, unsigned long id, char *name);
 void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
+void stream_sdp_label(metafile_t *mf, unsigned long id, unsigned long *label);
 void stream_close(stream_t *stream);
 void stream_free(stream_t *stream);
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -57,8 +57,7 @@ struct stream_s {
 	handler_t handler;
 	unsigned int forwarding_on:1;
 	double start_time;
-	unsigned int media;
-	unsigned int sdp_label;
+	unsigned int media_sdp_id;
 };
 typedef struct stream_s stream_t;
 
@@ -159,7 +158,6 @@ struct metafile_s {
 	unsigned int discard:1;
 	unsigned int db_metadata_done:1;
 	unsigned int skip_db:1;
-
 };
 
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -57,6 +57,7 @@ struct stream_s {
 	handler_t handler;
 	unsigned int forwarding_on:1;
 	double start_time;
+	unsigned int media;
 };
 typedef struct stream_s stream_t;
 
@@ -157,7 +158,6 @@ struct metafile_s {
 	unsigned int discard:1;
 	unsigned int db_metadata_done:1;
 	unsigned int skip_db:1;
-	unsigned int media;
 
 };
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -58,6 +58,7 @@ struct stream_s {
 	unsigned int forwarding_on:1;
 	double start_time;
 	unsigned int media;
+	unsigned int sdp_label;
 };
 typedef struct stream_s stream_t;
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -157,6 +157,8 @@ struct metafile_s {
 	unsigned int discard:1;
 	unsigned int db_metadata_done:1;
 	unsigned int skip_db:1;
+	unsigned int media;
+
 };
 
 


### PR DESCRIPTION
This should allow mix outpout per media instead of per flow.

One advantage is to identify caller an callee in case of siprec with dual media :

m=audio 41828 RTP/AVP 8 9 0 101
a=rtpmap:9 G722/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-15
a=ptime:20
a=sendonly
a=label:1
m=audio 41830 RTP/AVP 8 9 0 101
a=rtpmap:9 G722/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-15
a=ptime:20
a=sendonly
a=label:2

My dev's skills are limited so i'm opened to any remark.
