### PR TITLE
Some DTMF injection fixes

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2295,10 +2295,12 @@ static tc_code packet_dtmf(struct codec_ssrc_handler *ch, struct codec_ssrc_hand
 					ret = TCC_CONSUMED;
 				else
 					ret = packet_dtmf_fwd(ch, input_ch, dup, mp);
+				mp->ssrc_out->parent->seq_diff++;
 
 				if (ret != TCC_CONSUMED)
 					__transcode_packet_free(dup);
 			}
+			mp->ssrc_out->parent->seq_diff--;
 
 			// discard the received event
 			do_blocking = true;

--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2666,7 +2666,7 @@ void codec_add_dtmf_event(struct codec_ssrc_handler *ch, int code, int level, ui
 uint64_t codec_last_dtmf_event(struct codec_ssrc_handler *ch) {
 	struct dtmf_event *ev = t_queue_peek_tail(&ch->dtmf_events);
 	if (!ev)
-		return 0;
+		ev = &ch->dtmf_state;
 	return ev->ts;
 }
 

--- a/daemon/dtmf.c
+++ b/daemon/dtmf.c
@@ -849,7 +849,9 @@ const char *dtmf_inject(struct call_media *media, int code, int volume, int dura
 			ssrc_in->parent->h.ssrc);
 
 	// synthesise start and stop events
-	uint64_t num_samples = (uint64_t) duration * ch->dest_pt.clock_rate / 1000;
+	// the num_samples needs to be based on the the previous packet timestamp so we need to
+	// reduce it by one packets worth or we'll generate one too many packets than requested
+	uint64_t num_samples = (uint64_t) (duration - ch->dest_pt.ptime) * ch->dest_pt.clock_rate / 1000;
 	uint64_t start_pts = codec_encoder_pts(csh, ssrc_in);
 	uint64_t last_end_pts = codec_last_dtmf_event(csh);
 	if (last_end_pts) {

--- a/daemon/dtmf.c
+++ b/daemon/dtmf.c
@@ -207,14 +207,21 @@ static void dtmf_end_event(struct call_media *media, unsigned int event, unsigne
 	if (!clockrate)
 		clockrate = 8000;
 
-	struct dtmf_event *ev = g_slice_alloc0(sizeof(*ev));
-	*ev = (struct dtmf_event) { .code = 0, .ts = ts, .volume = 0 };
-	t_queue_push_tail(&media->dtmf_recv, ev);
+	// don't add to recv list when it's injected, it can cause the list TS's to be out
+	// of order breaking the dtmf-security and letting the generated PCM frames through
+	if (!injected) {
+		struct dtmf_event *ev = g_slice_alloc0(sizeof(*ev));
+		*ev = (struct dtmf_event) { .code = 0, .ts = ts, .volume = 0 };
+		t_queue_push_tail(&media->dtmf_recv, ev);
+	}
 
-	ev = g_slice_alloc0(sizeof(*ev));
-	*ev = (struct dtmf_event) { .code = 0, .ts = ts + media->monologue->dtmf_delay * clockrate / 1000,
-		.volume = 0, .block_dtmf = media->monologue->block_dtmf };
-	t_queue_push_tail(&media->dtmf_send, ev);
+	// only add to send list if injected, a delayed send, or not being blocked
+	if (injected || !media->monologue->block_dtmf || media->monologue->dtmf_delay) {
+		struct dtmf_event *ev = g_slice_alloc0(sizeof(*ev));
+		*ev = (struct dtmf_event) { .code = 0, .ts = ts + media->monologue->dtmf_delay * clockrate / 1000,
+			.volume = 0, .block_dtmf = media->monologue->block_dtmf };
+		t_queue_push_tail(&media->dtmf_send, ev);
+	}
 
 	if (!dtmf_do_logging(media->call, injected))
 		return;
@@ -477,7 +484,7 @@ static void dtmf_check_trigger(struct call_media *media, char event, uint64_t ts
 }
 
 // media->dtmf_lock must be held
-static void dtmf_code_event(struct call_media *media, char event, uint64_t ts, int clockrate, int volume) {
+static void dtmf_code_event(struct call_media *media, char event, uint64_t ts, int clockrate, int volume, bool injected) {
 	struct dtmf_event *ev = t_queue_peek_tail(&media->dtmf_recv);
 	if (ev && ev->code == event)
 		return;
@@ -487,16 +494,23 @@ static void dtmf_code_event(struct call_media *media, char event, uint64_t ts, i
 	// check trigger before setting new dtmf_start
 	dtmf_check_trigger(media, event, ts, clockrate);
 
-	ev = g_slice_alloc0(sizeof(*ev));
-	*ev = (struct dtmf_event) { .code = event, .ts = ts, .volume = volume,
-		.rand_code = '0' + (ssl_random() % 10), .index = media->dtmf_count };
-	t_queue_push_tail(&media->dtmf_recv, ev);
+	// don't add to recv list when it's injected, it can cause the list TS's to be out
+	// of order breaking the dtmf-security and letting the generated PCM frames through
+	if (!injected) {
+		ev = g_slice_alloc0(sizeof(*ev));
+		*ev = (struct dtmf_event) { .code = event, .ts = ts, .volume = volume,
+			.rand_code = '0' + (ssl_random() % 10), .index = media->dtmf_count };
+		t_queue_push_tail(&media->dtmf_recv, ev);
+	}
 
-	ev = g_slice_alloc0(sizeof(*ev));
-	*ev = (struct dtmf_event) { .code = event, .ts = ts + media->monologue->dtmf_delay * clockrate / 1000,
-		.volume = volume,
-		.block_dtmf = media->monologue->block_dtmf };
-	t_queue_push_tail(&media->dtmf_send, ev);
+	// only add to send list if injected, a delayed send, or not being blocked
+	if (injected || !media->monologue->block_dtmf || media->monologue->dtmf_delay) {
+		ev = g_slice_alloc0(sizeof(*ev));
+		*ev = (struct dtmf_event) { .code = event, .ts = ts + media->monologue->dtmf_delay * clockrate / 1000,
+			.volume = volume,
+			.block_dtmf = media->monologue->block_dtmf };
+		t_queue_push_tail(&media->dtmf_send, ev);
+	}
 
 	media->dtmf_count++;
 }
@@ -561,7 +575,7 @@ int dtmf_event_packet(struct media_packet *mp, str *payload, int clockrate, uint
 			dtmf->event, dtmf->volume, dtmf->end, duration);
 
 	if (!dtmf->end) {
-		dtmf_code_event(mp->media, dtmf_code_to_char(dtmf->event), ts, clockrate, dtmf->volume);
+		dtmf_code_event(mp->media, dtmf_code_to_char(dtmf->event), ts, clockrate, dtmf->volume, false);
 		return 0;
 	}
 
@@ -613,7 +627,7 @@ void dtmf_dsp_event(const struct dtmf_event *new_event, struct dtmf_event *cur_e
 		int code = dtmf_code_from_char(new_event->code); // for validation
 		if (code != -1)
 			dtmf_code_event(media, (char) new_event->code, ts, clockrate,
-					dtmf_volume_from_dsp(new_event->volume));
+					dtmf_volume_from_dsp(new_event->volume), injected);
 	}
 }
 

--- a/t/auto-daemon-tests.pl
+++ b/t/auto-daemon-tests.pl
@@ -1658,15 +1658,13 @@ rcv($sock_b, $port_a, rtpm(101, 1005, 3480, 0x1234, "\x00\x0a\x01\xe0"));
 snd($sock_a, $port_b, rtp(8, 1006, 3960, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(101, 1006, 3480, 0x1234, "\x00\x0a\x02\x80"));
 snd($sock_a, $port_b, rtp(8, 1007, 4120, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(101, 1007, 3480, 0x1234, "\x00\x0a\x03\x20"));
-snd($sock_a, $port_b, rtp(8, 1008, 4280, 0x1234, "\x00" x 160));
 # end event
-rcv($sock_b, $port_a, rtpm(101, 1008, 3480, 0x1234, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1009, 3480, 0x1234, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1010, 3480, 0x1234, "\x00\x8a\x03\xc0"));
+rcv($sock_b, $port_a, rtpm(101, 1007, 3480, 0x1234, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1008, 3480, 0x1234, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1009, 3480, 0x1234, "\x00\x8a\x03\x20"));
 
-snd($sock_a, $port_b, rtp(8, 1009, 4440, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1011, 4440, 0x1234, "\x00" x 160));
+snd($sock_a, $port_b, rtp(8, 1008, 4280, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1010, 4280, 0x1234, "\x00" x 160));
 
 
 
@@ -1774,15 +1772,13 @@ rcv($sock_b, $port_a, rtpm(101, 1016, 4920, 0x1234, "\x00\x0a\x01\xe0"));
 snd($sock_a, $port_b, rtp(8, 1017, 5400, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(101, 1017, 4920, 0x1234, "\x00\x0a\x02\x80"));
 snd($sock_a, $port_b, rtp(8, 1018, 5560, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(101, 1018, 4920, 0x1234, "\x00\x0a\x03\x20"));
-snd($sock_a, $port_b, rtp(8, 1019, 5720, 0x1234, "\x00" x 160));
 # end event
-rcv($sock_b, $port_a, rtpm(101, 1019, 4920, 0x1234, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1020, 4920, 0x1234, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1021, 4920, 0x1234, "\x00\x8a\x03\xc0"));
+rcv($sock_b, $port_a, rtpm(101, 1018, 4920, 0x1234, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1019, 4920, 0x1234, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1020, 4920, 0x1234, "\x00\x8a\x03\x20"));
 
-snd($sock_a, $port_b, rtp(8, 1020, 5880, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1022, 5880, 0x1234, "\x00" x 160));
+snd($sock_a, $port_b, rtp(8, 1019, 5720, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1021, 5720, 0x1234, "\x00" x 160));
 
 snd($sock_a, $port_b, rtp(101 | 0x80, 1021, 6040, 0x1234, "\x03\x26\x00\xa0"));
 rcv_no($sock_b);
@@ -1800,19 +1796,16 @@ snd($sock_a, $port_b, rtp(101, 1025, 6040, 0x1234, "\x03\x26\x03\x20"));
 rcv($sock_b, $port_a, rtpm(101, 1027, 6200, 0x1234, "\x01\x0c\x02\x80"));
 # send end event
 snd($sock_a, $port_b, rtp(101, 1026, 6040, 0x1234, "\x03\xa6\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1028, 6200, 0x1234, "\x01\x0c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1028, 6200, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1029, 6200, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1030, 6200, 0x1234, "\x01\x8c\x03\x20"));
 snd($sock_a, $port_b, rtp(101, 1027, 6040, 0x1234, "\x03\xa6\x03\xc0"));
 rcv_no($sock_b);
 snd($sock_a, $port_b, rtp(101, 1028, 6040, 0x1234, "\x03\xa6\x03\xc0"));
 rcv_no($sock_b);
 # send audio, receive end event
 snd($sock_a, $port_b, rtp(8, 1029, 7000, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(101, 1029, 6200, 0x1234, "\x01\x8c\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1030, 6200, 0x1234, "\x01\x8c\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1031, 6200, 0x1234, "\x01\x8c\x03\xc0"));
-
-snd($sock_a, $port_b, rtp(8, 1030, 7160, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1032, 7160, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1033, 7000, 0x1234, "\x00" x 160));
 
 
 
@@ -14563,13 +14556,11 @@ rcv($sock_b, $port_a, rtpm(96, 1004, 3320, $ssrc, "\x00\x0a\x01\xe0"));
 snd($sock_a, $port_b, rtp(0, 1005, 3800, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(96, 1005, 3320, $ssrc, "\x00\x0a\x02\x80"));
 snd($sock_a, $port_b, rtp(0, 1006, 3960, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x0a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\x20"));
 snd($sock_a, $port_b, rtp(0, 1007, 4120, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1009, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-snd($sock_a, $port_b, rtp(0, 1008, 4280, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(0, 1010, 4280, $ssrc, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(0, 1009, 4120, $ssrc, "\x00" x 160));
 
 
 
@@ -14590,13 +14581,11 @@ rcv($sock_a, $port_b, rtpm(96, 4004, 8320, $ssrc, "\x0a\x0a\x01\xe0"));
 snd($sock_b, $port_a, rtp(0, 4005, 8800, 0x6543, "\x00" x 160));
 rcv($sock_a, $port_b, rtpm(96, 4005, 8320, $ssrc, "\x0a\x0a\x02\x80"));
 snd($sock_b, $port_a, rtp(0, 4006, 8960, 0x6543, "\x00" x 160));
-rcv($sock_a, $port_b, rtpm(96, 4006, 8320, $ssrc, "\x0a\x0a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4006, 8320, $ssrc, "\x0a\x8a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4007, 8320, $ssrc, "\x0a\x8a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4008, 8320, $ssrc, "\x0a\x8a\x03\x20"));
 snd($sock_b, $port_a, rtp(0, 4007, 9120, 0x6543, "\x00" x 160));
-rcv($sock_a, $port_b, rtpm(96, 4007, 8320, $ssrc, "\x0a\x8a\x03\xc0"));
-rcv($sock_a, $port_b, rtpm(96, 4008, 8320, $ssrc, "\x0a\x8a\x03\xc0"));
-rcv($sock_a, $port_b, rtpm(96, 4009, 8320, $ssrc, "\x0a\x8a\x03\xc0"));
-snd($sock_b, $port_a, rtp(0, 4008, 9280, 0x6543, "\x00" x 160));
-rcv($sock_a, $port_b, rtpm(0, 4010, 9280, $ssrc, "\x00" x 160));
+rcv($sock_a, $port_b, rtpm(0, 4009, 9120, $ssrc, "\x00" x 160));
 
 
 
@@ -14670,13 +14659,11 @@ rcv($sock_b, $port_a, rtpm(96, 1004, 3320, $ssrc, "\x00\x0a\x01\xe0"));
 snd($sock_a, $port_b, rtp(0, 1005, 3800, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(96, 1005, 3320, $ssrc, "\x00\x0a\x02\x80"));
 snd($sock_a, $port_b, rtp(0, 1006, 3960, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x0a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\x20"));
 snd($sock_a, $port_b, rtp(0, 1007, 4120, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1009, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-snd($sock_a, $port_b, rtp(0, 1008, 4280, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1010, 4280, $ssrc, "\x2a" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1009, 4120, $ssrc, "\x2a" x 160));
 
 
 
@@ -14697,13 +14684,11 @@ rcv($sock_a, $port_b, rtpm(96, 4004, 8320, $ssrc, "\x0b\x0a\x01\xe0"));
 snd($sock_b, $port_a, rtp(8, 4005, 8800, 0x6543, "\x2a" x 160));
 rcv($sock_a, $port_b, rtpm(96, 4005, 8320, $ssrc, "\x0b\x0a\x02\x80"));
 snd($sock_b, $port_a, rtp(8, 4006, 8960, 0x6543, "\x2a" x 160));
-rcv($sock_a, $port_b, rtpm(96, 4006, 8320, $ssrc, "\x0b\x0a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4006, 8320, $ssrc, "\x0b\x8a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4007, 8320, $ssrc, "\x0b\x8a\x03\x20"));
+rcv($sock_a, $port_b, rtpm(96, 4008, 8320, $ssrc, "\x0b\x8a\x03\x20"));
 snd($sock_b, $port_a, rtp(8, 4007, 9120, 0x6543, "\x2a" x 160));
-rcv($sock_a, $port_b, rtpm(96, 4007, 8320, $ssrc, "\x0b\x8a\x03\xc0"));
-rcv($sock_a, $port_b, rtpm(96, 4008, 8320, $ssrc, "\x0b\x8a\x03\xc0"));
-rcv($sock_a, $port_b, rtpm(96, 4009, 8320, $ssrc, "\x0b\x8a\x03\xc0"));
-snd($sock_b, $port_a, rtp(8, 4008, 9280, 0x6543, "\x2a" x 160));
-rcv($sock_a, $port_b, rtpm(0, 4010, 9280, $ssrc, "\x00" x 160));
+rcv($sock_a, $port_b, rtpm(0, 4009, 9120, $ssrc, "\x00" x 160));
 
 
 
@@ -15133,11 +15118,11 @@ rcv($sock_b, $port_a, rtpm(96, 1004, 3320, $ssrc, "\x00\x0a\x01\xe0"));
 snd($sock_a, $port_b, rtp(0, 1005, 3800, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(96, 1005, 3320, $ssrc, "\x00\x0a\x02\x80"));
 snd($sock_a, $port_b, rtp(0, 1006, 3960, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x0a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1006, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\x20"));
 snd($sock_a, $port_b, rtp(0, 1007, 4120, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1007, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1008, 3320, $ssrc, "\x00\x8a\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1009, 3320, $ssrc, "\x00\x8a\x03\xc0"));
+rcv($sock_b, $port_a, rtpm(0, 1009, 4120, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1008, 4280, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(0, 1010, 4280, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1009, 4440, 0x1234, "\x00" x 160));
@@ -15145,23 +15130,19 @@ rcv($sock_b, $port_a, rtpm(0, 1011, 4440, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1010, 4600, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(0, 1012, 4600, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1011, 4760, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(0, 1013, 4760, $ssrc, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(96 | 0x80, 1013, 4760, $ssrc, "\x01\x06\x00\xa0"));
 snd($sock_a, $port_b, rtp(0, 1012, 4920, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96 | 0x80, 1014, 4920, $ssrc, "\x01\x06\x00\xa0"));
+rcv($sock_b, $port_a, rtpm(96, 1014, 4760, $ssrc, "\x01\x06\x01\x40"));
 snd($sock_a, $port_b, rtp(0, 1013, 5080, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1015, 4920, $ssrc, "\x01\x06\x01\x40"));
+rcv($sock_b, $port_a, rtpm(96, 1015, 4760, $ssrc, "\x01\x06\x01\xe0"));
 snd($sock_a, $port_b, rtp(0, 1014, 5240, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1016, 4920, $ssrc, "\x01\x06\x01\xe0"));
+rcv($sock_b, $port_a, rtpm(96, 1016, 4760, $ssrc, "\x01\x06\x02\x80"));
 snd($sock_a, $port_b, rtp(0, 1015, 5400, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1017, 4920, $ssrc, "\x01\x06\x02\x80"));
+rcv($sock_b, $port_a, rtpm(96, 1017, 4760, $ssrc, "\x01\x86\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1018, 4760, $ssrc, "\x01\x86\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1019, 4760, $ssrc, "\x01\x86\x03\x20"));
 snd($sock_a, $port_b, rtp(0, 1016, 5560, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1018, 4920, $ssrc, "\x01\x06\x03\x20"));
-snd($sock_a, $port_b, rtp(0, 1017, 5720, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1019, 4920, $ssrc, "\x01\x86\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1020, 4920, $ssrc, "\x01\x86\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(96, 1021, 4920, $ssrc, "\x01\x86\x03\xc0"));
-snd($sock_a, $port_b, rtp(0, 1018, 5880, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(0, 1022, 5880, $ssrc, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(0, 1020, 5560, $ssrc, "\x00" x 160));
 
 
 

--- a/t/auto-daemon-tests.pl
+++ b/t/auto-daemon-tests.pl
@@ -1787,25 +1787,27 @@ $resp = rtpe_req('play DTMF', 'inject DTMF towards B over received DTMF',
        { 'from-tag' => ft(), code => '1', volume => 12, duration => 100 });
 
 snd($sock_a, $port_b, rtp(101, 1022, 6040, 0x1234, "\x03\x26\x01\x40"));
-rcv($sock_b, $port_a, rtpm(101 | 0x80, 1024, 6200, 0x1234, "\x01\x0c\x00\xa0"));
+rcv_no($sock_b);
 snd($sock_a, $port_b, rtp(101, 1023, 6040, 0x1234, "\x03\x26\x01\xe0"));
-rcv($sock_b, $port_a, rtpm(101, 1025, 6200, 0x1234, "\x01\x0c\x01\x40"));
+rcv($sock_b, $port_a, rtpm(101 | 0x80, 1025, 6360, 0x1234, "\x01\x0c\x00\xa0"));
 snd($sock_a, $port_b, rtp(101, 1024, 6040, 0x1234, "\x03\x26\x02\x80"));
-rcv($sock_b, $port_a, rtpm(101, 1026, 6200, 0x1234, "\x01\x0c\x01\xe0"));
+rcv($sock_b, $port_a, rtpm(101, 1026, 6360, 0x1234, "\x01\x0c\x01\x40"));
 snd($sock_a, $port_b, rtp(101, 1025, 6040, 0x1234, "\x03\x26\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1027, 6200, 0x1234, "\x01\x0c\x02\x80"));
+rcv($sock_b, $port_a, rtpm(101, 1027, 6360, 0x1234, "\x01\x0c\x01\xe0"));
 # send end event
 snd($sock_a, $port_b, rtp(101, 1026, 6040, 0x1234, "\x03\xa6\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1028, 6200, 0x1234, "\x01\x8c\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1029, 6200, 0x1234, "\x01\x8c\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1030, 6200, 0x1234, "\x01\x8c\x03\x20"));
 snd($sock_a, $port_b, rtp(101, 1027, 6040, 0x1234, "\x03\xa6\x03\xc0"));
-rcv_no($sock_b);
 snd($sock_a, $port_b, rtp(101, 1028, 6040, 0x1234, "\x03\xa6\x03\xc0"));
+rcv($sock_b, $port_a, rtpm(101, 1028, 6360, 0x1234, "\x01\x0c\x02\x80"));
 rcv_no($sock_b);
 # send audio, receive end event
 snd($sock_a, $port_b, rtp(8, 1029, 7000, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1033, 7000, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(101, 1029, 6360, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1030, 6360, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1031, 6360, 0x1234, "\x01\x8c\x03\x20"));
+
+snd($sock_a, $port_b, rtp(8, 1030, 7160, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1032, 7160, 0x1234, "\x00" x 160));
 
 
 

--- a/t/auto-daemon-tests.pl
+++ b/t/auto-daemon-tests.pl
@@ -1789,25 +1789,27 @@ $resp = rtpe_req('play DTMF', 'inject DTMF towards B over received DTMF',
 snd($sock_a, $port_b, rtp(101, 1022, 6040, 0x1234, "\x03\x26\x01\x40"));
 rcv_no($sock_b);
 snd($sock_a, $port_b, rtp(101, 1023, 6040, 0x1234, "\x03\x26\x01\xe0"));
-rcv($sock_b, $port_a, rtpm(101 | 0x80, 1025, 6360, 0x1234, "\x01\x0c\x00\xa0"));
+rcv_no($sock_b);
 snd($sock_a, $port_b, rtp(101, 1024, 6040, 0x1234, "\x03\x26\x02\x80"));
-rcv($sock_b, $port_a, rtpm(101, 1026, 6360, 0x1234, "\x01\x0c\x01\x40"));
+rcv($sock_b, $port_a, rtpm(101 | 0x80, 1026, 6520, 0x1234, "\x01\x0c\x00\xa0"));
 snd($sock_a, $port_b, rtp(101, 1025, 6040, 0x1234, "\x03\x26\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1027, 6360, 0x1234, "\x01\x0c\x01\xe0"));
+rcv($sock_b, $port_a, rtpm(101, 1027, 6520, 0x1234, "\x01\x0c\x01\x40"));
 # send end event
 snd($sock_a, $port_b, rtp(101, 1026, 6040, 0x1234, "\x03\xa6\x03\xc0"));
 snd($sock_a, $port_b, rtp(101, 1027, 6040, 0x1234, "\x03\xa6\x03\xc0"));
 snd($sock_a, $port_b, rtp(101, 1028, 6040, 0x1234, "\x03\xa6\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1028, 6360, 0x1234, "\x01\x0c\x02\x80"));
+rcv($sock_b, $port_a, rtpm(101, 1028, 6520, 0x1234, "\x01\x0c\x01\xe0"));
 rcv_no($sock_b);
 # send audio, receive end event
 snd($sock_a, $port_b, rtp(8, 1029, 7000, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(101, 1029, 6360, 0x1234, "\x01\x8c\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1030, 6360, 0x1234, "\x01\x8c\x03\x20"));
-rcv($sock_b, $port_a, rtpm(101, 1031, 6360, 0x1234, "\x01\x8c\x03\x20"));
-
+rcv($sock_b, $port_a, rtpm(101, 1029, 6520, 0x1234, "\x01\x0c\x02\x80"));
 snd($sock_a, $port_b, rtp(8, 1030, 7160, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1032, 7160, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(101, 1030, 6520, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1031, 6520, 0x1234, "\x01\x8c\x03\x20"));
+rcv($sock_b, $port_a, rtpm(101, 1032, 6520, 0x1234, "\x01\x8c\x03\x20"));
+
+snd($sock_a, $port_b, rtp(8, 1031, 7320, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1033, 7320, 0x1234, "\x00" x 160));
 
 
 
@@ -15132,19 +15134,21 @@ rcv($sock_b, $port_a, rtpm(0, 1011, 4440, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1010, 4600, 0x1234, "\x00" x 160));
 rcv($sock_b, $port_a, rtpm(0, 1012, 4600, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1011, 4760, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96 | 0x80, 1013, 4760, $ssrc, "\x01\x06\x00\xa0"));
+rcv($sock_b, $port_a, rtpm(0, 1013, 4760, $ssrc, "\x00" x 160));
 snd($sock_a, $port_b, rtp(0, 1012, 4920, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1014, 4760, $ssrc, "\x01\x06\x01\x40"));
+rcv($sock_b, $port_a, rtpm(96 | 0x80, 1014, 4920, $ssrc, "\x01\x06\x00\xa0"));
 snd($sock_a, $port_b, rtp(0, 1013, 5080, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1015, 4760, $ssrc, "\x01\x06\x01\xe0"));
+rcv($sock_b, $port_a, rtpm(96, 1015, 4920, $ssrc, "\x01\x06\x01\x40"));
 snd($sock_a, $port_b, rtp(0, 1014, 5240, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1016, 4760, $ssrc, "\x01\x06\x02\x80"));
+rcv($sock_b, $port_a, rtpm(96, 1016, 4920, $ssrc, "\x01\x06\x01\xe0"));
 snd($sock_a, $port_b, rtp(0, 1015, 5400, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(96, 1017, 4760, $ssrc, "\x01\x86\x03\x20"));
-rcv($sock_b, $port_a, rtpm(96, 1018, 4760, $ssrc, "\x01\x86\x03\x20"));
-rcv($sock_b, $port_a, rtpm(96, 1019, 4760, $ssrc, "\x01\x86\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1017, 4920, $ssrc, "\x01\x06\x02\x80"));
 snd($sock_a, $port_b, rtp(0, 1016, 5560, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(0, 1020, 5560, $ssrc, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(96, 1018, 4920, $ssrc, "\x01\x86\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1019, 4920, $ssrc, "\x01\x86\x03\x20"));
+rcv($sock_b, $port_a, rtpm(96, 1020, 4920, $ssrc, "\x01\x86\x03\x20"));
+snd($sock_a, $port_b, rtp(0, 1017, 5720, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(0, 1021, 5720, $ssrc, "\x00" x 160));
 
 
 

--- a/t/auto-daemon-tests.pl
+++ b/t/auto-daemon-tests.pl
@@ -1807,12 +1807,12 @@ snd($sock_a, $port_b, rtp(101, 1028, 6040, 0x1234, "\x03\xa6\x03\xc0"));
 rcv_no($sock_b);
 # send audio, receive end event
 snd($sock_a, $port_b, rtp(8, 1029, 7000, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(101, 1029, 6200, 0x1234, "\x01\x8c\x03\xc0"));
+rcv($sock_b, $port_a, rtpm(101, 1030, 6200, 0x1234, "\x01\x8c\x03\xc0"));
 rcv($sock_b, $port_a, rtpm(101, 1031, 6200, 0x1234, "\x01\x8c\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1032, 6200, 0x1234, "\x01\x8c\x03\xc0"));
-rcv($sock_b, $port_a, rtpm(101, 1033, 6200, 0x1234, "\x01\x8c\x03\xc0"));
 
 snd($sock_a, $port_b, rtp(8, 1030, 7160, 0x1234, "\x00" x 160));
-rcv($sock_b, $port_a, rtpm(8, 1034, 7160, 0x1234, "\x00" x 160));
+rcv($sock_b, $port_a, rtpm(8, 1032, 7160, 0x1234, "\x00" x 160));
 
 
 


### PR DESCRIPTION
A few scenarios are fixed for me with these changes.

> packet_encoded_tx: add a ts delay when transmitting DTMF event packets

This fixes not passing a `ts_delay` into `codec_output_rtp` resulting in packets not being scheduled correctly (like already happens in `codec_add_dtmf_packet`) and an, eg, 100ms event has all packets transmitted in as few as 20ms

>  dtmf_event_payload: canonicalise DTMF end event ts if start packet send was delayed

in some scenarios DTMF injected with, eg, 100ms duration are transmitted much shorter due to the start time being adjusted but not the end time

> dtmf_inject: fix generating one too many event packets

the starting value used to add num_samples to is that of the current packet, which is already increased from the previous packet. The result is a 100ms injection coming through as 6 packets with a total event-duration of 960
dtmf_inject: adjust start_pts if last_event + pause is later than it

> codec_last_dtmf_event: return ts of dtmf_state if handler queue is empty
  dtmf_inject: adjust start_pts if last_event + pause is later than it

DTMF requires an inter-digit pause, which is allowed for with the `pause` parameter. However, this is only accounted for if an injection request comes in during an insertion, as its the event queue used to return the last event end timestamp. If there's nothing on the queue, we can fall back to the `dtmf_state` var as that seems to always be the most recent. 
The second commit can now use this value to calculate a minimum start ts for the injected event to ensure the pause is accounted for. Similar to the previous change, the actual time is increased by one packet's worth of samples to avoid an 100ms pause only having 80ms worth of packets

> dtmf: only update recv list if not injected and send list if injected, delayed or not blocked

when the DTMF-security mode is one of the values between `PCM_REPLACE_START/END`, the event packets are transcoded to PCM DTMF. Injected DTMF gets added to the `dtmf_recv` list and can cause out of order timestamp in the list, resulting in `is_in_dtmf` incorrectly returning `NULL`, resulting in those PCM DTMF frames leaking through.
I'm not sure if its needed, but to me it seems logical that maintaining separate lists for `recv` and `send` shouldn't result in them being basically identical by always adding all events to it (other than an adjusted ts for dtmf-delay). So have included a change only add to the send list if its injected, unblocked or being delayed. This way each list contains only contains the relevant events.


