### PR TITLE
Fix crash when injecting DTMF into encrypted stream

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -1717,7 +1717,13 @@ void codec_add_raw_packet(struct media_packet *mp, unsigned int clockrate) {
 #ifdef WITH_TRANSCODING
 static void codec_add_raw_packet_dup(struct media_packet *mp, unsigned int clockrate) {
 	struct codec_packet *p = g_slice_alloc0(sizeof(*p));
-	str_init_dup_str(&p->s, &mp->raw);
+	// don't just duplicate the string. need to ensure enough room
+	// if encryption is enabled on this stream
+	char *buf = g_malloc(mp->raw.len + 1 + RTP_BUFFER_TAIL_ROOM);
+	if (mp->raw.s && mp->raw.len)
+		memcpy(buf, mp->raw.s, mp->raw.len);
+	p->s.len = mp->raw.len;
+	p->s.s = buf;
 	p->free_func = free;
 	p->rtp = (struct rtp_header *) p->s.s;
 	codec_add_raw_packet_common(mp, clockrate, p);


### PR DESCRIPTION
we were getting crashes in random places when using play-DTMF on an encrypted stream, always with the message `corrupted size vs. prev_size`. I built with address sanitizers enabled and got more useful output:

```
==96816==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000105861 at pc 0x7f930a4e958d bp 0x7f92f49874d0 sp 0x7f92f4986c78
WRITE of size 10 at 0x603000105861 thread T40
    #0 0x7f930a4e958c in __interceptor_memcpy ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:790
    #1 0x55dc9c2de9fa in hmac_sha1_rtp /home/tom.briden/rtpengine/daemon/crypto.c:848
    #2 0x55dc9c2e5954 in rtp_avp2savp /home/tom.briden/rtpengine/daemon/rtp.c:135
    #3 0x55dc9c4615c8 in call_avp2savp_rtp /home/tom.briden/rtpengine/daemon/media_socket.c:1320
    #4 0x55dc9c489550 in media_packet_encrypt /home/tom.briden/rtpengine/daemon/media_socket.c:2365
    #5 0x55dc9c489d08 in __media_packet_encrypt /home/tom.briden/rtpengine/daemon/media_socket.c:2386
    #6 0x55dc9c4aae67 in stream_packet /home/tom.briden/rtpengine/daemon/media_socket.c:3012
    #7 0x55dc9c4b0e6b in stream_fd_readable /home/tom.briden/rtpengine/daemon/media_socket.c:3204
    #8 0x55dc9c72bba0 in poller_poll /home/tom.briden/rtpengine/daemon/poller.c:284
    #9 0x55dc9c72e8e3 in poller_loop2 /home/tom.briden/rtpengine/daemon/poller.c:389
    #10 0x55dc9c0d9f09 in thread_detach_func /home/tom.briden/rtpengine/daemon/helpers.c:258
    #11 0x7f93073b3608 in start_thread /build/glibc-e2p3jK/glibc-2.31/nptl/pthread_create.c:477
    #12 0x7f9306867352 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f352)

0x603000105861 is located 0 bytes to the right of 17-byte region [0x603000105850,0x603000105861)
allocated by thread T40 here:
    #0 0x7f930a55b808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7f930a226e98 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x57e98)
    #2 0x55dc9c5c83bb in __buffer_delay_raw /home/tom.briden/rtpengine/daemon/codec.c:2720
    #3 0x55dc9c5c3619 in handler_func_passthrough_ssrc /home/tom.briden/rtpengine/daemon/codec.c:2542
    #4 0x55dc9c4a9b63 in stream_packet /home/tom.briden/rtpengine/daemon/media_socket.c:2954
    #5 0x55dc9c4b0e6b in stream_fd_readable /home/tom.briden/rtpengine/daemon/media_socket.c:3204
    #6 0x55dc9c72bba0 in poller_poll /home/tom.briden/rtpengine/daemon/poller.c:284
    #7 0x55dc9c72e8e3 in poller_loop2 /home/tom.briden/rtpengine/daemon/poller.c:389
    #8 0x55dc9c0d9f09 in thread_detach_func /home/tom.briden/rtpengine/daemon/helpers.c:258
    #9 0x7f93073b3608 in start_thread /build/glibc-e2p3jK/glibc-2.31/nptl/pthread_create.c:477

```

I narrowed that down to the `codec_add_raw_packet_dup` function not allocating enough memory for the appended encryption data by only using `str_init_dup_str`, and then `hmac_sha1_rtp` doing a memcpy at the end of the string