### PR TITLE
Fix ipv stats when calls are restored from redis

### DIFF
--- a/daemon/redis.c
+++ b/daemon/redis.c
@@ -2090,6 +2090,8 @@ static void json_restore_call(struct redis *r, const str *callid, bool foreign) 
 	// set it to what we want, updating the statistics if needed
 	CALL_CLEAR(c, FOREIGN);
 	call_make_own_foreign(c, foreign);
+	bf_set_clear(&c->call_flags, CALL_FLAG_MEDIA_COUNTED, false);
+	statistics_update_ip46_inc_dec(c, CMC_INCREMENT);
 
 	err = NULL;
 


### PR DESCRIPTION
Basically I force increment when calls are restored from redis (because no monologue_offer_answer() is called for them in this restore path)