### PR TITLE
Add `flush_packets` flag to control output buffer flushing behavior

### DIFF
--- a/docs/rtpengine-recording.md
+++ b/docs/rtpengine-recording.md
@@ -359,6 +359,10 @@ sufficient for a standard installation of rtpengine.
 
     Forces one channel per media instead of SSRC. Note that this
     option is only useful if __\-\-output-mixed__ is also enabled.
+
+- __\-\-flush-packets__
+
+    Forces that the output buffer will be flushed after every packet, ensuring that the recording file grows steadily and becomes available for processing without delays.
 ## EXIT STATUS
 
 - __0__

--- a/etc/rtpengine-recording.conf
+++ b/etc/rtpengine-recording.conf
@@ -38,6 +38,9 @@ table = 0
 ### create one output file for each source
 # output-single = true
 
+### flush output to disk after each packet
+# flush-packets = true
+
 ### TCP/TLS output of PCM audio
 # tcp-send-to = 10.4.1.7:15413
 # tcp-resample = 16000

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -68,6 +68,7 @@ int notify_retries = 10;
 gboolean notify_record;
 gboolean notify_purge;
 gboolean mix_output_per_media = 0;
+gboolean flush_packets = 0;
 
 static GQueue threads = G_QUEUE_INIT; // only accessed from main thread
 
@@ -230,6 +231,7 @@ static void options(int *argc, char ***argv) {
 #if CURL_AT_LEAST_VERSION(7,56,0)
 		{ "notify-record", 	0,   0, G_OPTION_ARG_NONE,	&notify_record, "Also attach recorded file to request", NULL		},
 		{ "notify-purge", 	0,   0, G_OPTION_ARG_NONE,	&notify_purge,	"Remove the local file if notify success", NULL		},
+		{ "flush-packets", 	0,   0, G_OPTION_ARG_NONE,	&flush_packets,	"Output buffer will be flushed after every packet", NULL },
 #endif
 		{ NULL, }
 	};

--- a/recording-daemon/main.h
+++ b/recording-daemon/main.h
@@ -51,7 +51,7 @@ extern gboolean notify_record;
 extern gboolean notify_purge;
 extern gboolean mix_output_per_media;
 extern volatile int shutdown_flag;
-
+extern gboolean flush_packets;
 
 extern struct rtpengine_common_config rtpe_common_config;
 

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -341,6 +341,10 @@ got_fn:
 	if (av_ret)
 		goto err;
 
+	if (flush_packets) {
+		output->fmtctx->flags |= AVFMT_FLAG_FLUSH_PACKETS;
+	}
+
 	db_config_stream(output);
 	ilog(LOG_INFO, "Opened output media file '%s' for writing", full_fn);
 done:


### PR DESCRIPTION
This commit introduces a new configuration flag `flush_packets`, allowing control over whether the output buffer is flushed after each packet during recording. When enabled, the file will grow continuously, reducing latency and ensuring immediate availability for processing.