### PR TITLE
Added decoder mix "slots" concept, so that the desired wav channel ca…

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2571,6 +2571,9 @@ static void __call_monologue_init_from_flags(struct call_monologue *ml, sdp_ng_f
 
 	call->last_signal = rtpe_now.tv_sec;
 	call->deleted = 0;
+	call->media_rec_slots = (flags->media_rec_slots > 0 && call->media_rec_slots == 0)
+		                        ? flags->media_rec_slots
+		                        : call->media_rec_slots;
 
 	// consume session attributes
 	t_queue_clear_full(&ml->sdp_attributes, sdp_attr_free);
@@ -2789,10 +2792,9 @@ static void __media_init_from_flags(struct call_media *other_media, struct call_
 	}
 
 	if (flags->opmode == OP_OFFER) {
+		ilog(LOG_DEBUG, "setting other slot to %u, setting slot to %u", flags->media_rec_slot_offer, flags->media_rec_slot_answer);
 		other_media->media_rec_slot = flags->media_rec_slot_offer;
 		media->media_rec_slot = flags->media_rec_slot_answer;
-		media->media_rec_slots = flags->media_rec_slots;
-		other_media->media_rec_slots = flags->media_rec_slots;
 	}
 }
 

--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2787,6 +2787,13 @@ static void __media_init_from_flags(struct call_media *other_media, struct call_
 		if (sp->desired_family)
 			media->desired_family = sp->desired_family;
 	}
+
+	if (flags->opmode == OP_OFFER) {
+		other_media->media_rec_slot = flags->media_rec_slot_offer;
+		media->media_rec_slot = flags->media_rec_slot_answer;
+		media->media_rec_slots = flags->media_rec_slots;
+		other_media->media_rec_slots = flags->media_rec_slots;
+	}
 }
 
 unsigned int proto_num_ports(unsigned int sp_ports, struct call_media *media, sdp_ng_flags *flags,

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1738,6 +1738,17 @@ static void call_ng_main_flags(sdp_ng_flags *out, str *key, bencode_item_t *valu
 		case CSH_LOOKUP("recording file"):
 			out->recording_file = s;
 			break;
+		case CSH_LOOKUP("recording-media-slot-offer"):
+			// This needs to be > 0
+			out->media_rec_slot_offer = bencode_get_integer_str(value, out->media_rec_slot_offer);
+			break;
+		case CSH_LOOKUP("recording-media-slot-answer"):
+			// This needs to be > 0
+			out->media_rec_slot_answer = bencode_get_integer_str(value, out->media_rec_slot_answer);
+			break;
+		case CSH_LOOKUP("recording-media-slots"):
+			out->media_rec_slots = bencode_get_integer_str(value, out->media_rec_slots);
+			break;
 		case CSH_LOOKUP("passthrough"):
 		case CSH_LOOKUP("passthru"):
 			switch (__csh_lookup(&s)) {

--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -936,6 +936,8 @@ static void setup_stream_proc(struct packet_stream *stream) {
 	struct recording *recording = call->recording;
 	char buf[128];
 	int len;
+	unsigned int media_rec_slot;
+	unsigned int media_rec_slots;
 
 	if (!recording)
 		return;
@@ -946,9 +948,27 @@ static void setup_stream_proc(struct packet_stream *stream) {
 	if (ML_ISSET(ml, NO_RECORDING))
 		return;
 
-	len = snprintf(buf, sizeof(buf), "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64,
+	ilog(LOG_DEBUG, "media_rec_slot=%i, media_rec_slots=%i", media->media_rec_slot, media->media_rec_slots);
+
+	// If no slots have been specified then we set the variables up so that the mix
+	// channels will be used in sequence as each SSRC is seen. (see mix.c for the algorithm)
+	if(media->media_rec_slots == 0) {
+		media_rec_slot = 1;
+		media_rec_slots = 1;
+	} else {
+		media_rec_slot = media->media_rec_slot;
+		media_rec_slots = media->media_rec_slots;
+	}
+
+	if(media_rec_slot > media_rec_slots) {
+		ilog(LOG_ERR, "Stream slot %i is greater than the total number of slots available %i, setting to slot %i", media->media_rec_slot, media->media_rec_slots, media->media_rec_slots);
+		media->media_rec_slot = media->media_rec_slots;
+	}
+
+	// Note media_rec_slot is subtracted by 1 as it is passed to the recorder metafile interface. Channels are 0 indexed at the mix level
+	len = snprintf(buf, sizeof(buf), "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-REC-SLOT %i MEDIA-REC-SLOTS %i",
 			ml->unique_id, media->unique_id, media->index, stream->component,
-			atomic64_get_na(&stream->ps_flags));
+			atomic64_get_na(&stream->ps_flags), media_rec_slot-1, media_rec_slots);
 	append_meta_chunk(recording, buf, len, "STREAM %u details", stream->unique_id);
 
 	len = snprintf(buf, sizeof(buf), "tag-%u-media-%u-component-%u-%s-id-%u",

--- a/include/call.h
+++ b/include/call.h
@@ -466,6 +466,8 @@ struct call_media {
 	struct dtls_fingerprint fingerprint;			/* as received */
 	const struct dtls_hash_func *fp_hash_func;		/* outgoing */
 	str			tls_id;
+	unsigned int			media_rec_slot;
+	unsigned int			media_rec_slots;
 
 	packet_stream_q		streams;			/* normally RTP + RTCP */
 	endpoint_map_q		endpoint_maps;

--- a/include/call.h
+++ b/include/call.h
@@ -467,7 +467,6 @@ struct call_media {
 	const struct dtls_hash_func *fp_hash_func;		/* outgoing */
 	str			tls_id;
 	unsigned int			media_rec_slot;
-	unsigned int			media_rec_slots;
 
 	packet_stream_q		streams;			/* normally RTP + RTCP */
 	endpoint_map_q		endpoint_maps;
@@ -730,6 +729,8 @@ struct call {
 	enum block_dtmf_mode	block_dtmf;
 
 	atomic64		call_flags;
+
+	unsigned int media_rec_slots;
 };
 
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -111,6 +111,9 @@ struct sdp_ng_flags {
 	int trigger_end_digits;
 	int trigger_end_ms;
 	int dtmf_delay;
+	int media_rec_slot_offer;
+	int media_rec_slot_answer;
+	int media_rec_slots;
 	int repeat_times;
 	str file;
 	str blob;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -113,9 +113,8 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	// handle mix output
 	pthread_mutex_lock(&metafile->mix_lock);
 	if (metafile->mix_out) {
-		dbg("adding packet from stream #%lu to mix output, stream media_rec_slot is %i, slots is %i", stream->id, stream->media_rec_slot, stream->media_rec_slots);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media_rec_slot, stream->media_rec_slots);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->channel_slot);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -113,9 +113,9 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	// handle mix output
 	pthread_mutex_lock(&metafile->mix_lock);
 	if (metafile->mix_out) {
-		dbg("adding packet from stream #%lu to mix output", stream->id);
+		dbg("adding packet from stream #%lu to mix output, stream media_rec_slot is %i, slots is %i", stream->id, stream->media_rec_slot, stream->media_rec_slots);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media_rec_slot, stream->media_rec_slots);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -112,7 +112,10 @@ static void meta_stream_details(metafile_t *mf, unsigned long snum, char *conten
 	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-REC-SLOT %i MEDIA-REC-SLOTS %i",
 				&tag, &media, &tm, &cmp, &flags, &media_rec_slot, &media_rec_slots) != 7)
 		return;
-	stream_details(mf, snum, tag, media_rec_slot, media_rec_slots);
+	mix_set_channel_slots(mf->mix, media_rec_slots);
+
+	//User will have passed in slot 1,2,3 etc. Need to subtract 1 to convert to 0 indexed
+	stream_details(mf, snum, tag, media_rec_slot-1);
 }
 
 

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -107,12 +107,12 @@ static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *cont
 // mf is locked
 static void meta_stream_details(metafile_t *mf, unsigned long snum, char *content) {
 	dbg("stream %lu details %s", snum, content);
-	unsigned int tag, media, tm, cmp;
+	unsigned int tag, media, tm, cmp, media_rec_slot, media_rec_slots;
 	uint64_t flags;
-	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64,
-				&tag, &media, &tm, &cmp, &flags) != 5)
+	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-REC-SLOT %i MEDIA-REC-SLOTS %i",
+				&tag, &media, &tm, &cmp, &flags, &media_rec_slot, &media_rec_slots) != 7)
 		return;
-	stream_details(mf, snum, tag);
+	stream_details(mf, snum, tag, media_rec_slot, media_rec_slots);
 }
 
 

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -31,7 +31,8 @@ struct mix_s {
 	CH_LAYOUT_T channel_layout[MIX_MAX_INPUTS];
 	AVFilterContext *amix_ctx;
 	AVFilterContext *sink_ctx;
-	unsigned int input_idx;
+	unsigned int next_idx[MIX_MAX_INPUTS]; //slots can never exceed MIN_MAX_INPUTS by definition
+	unsigned int channel_slots;
 	AVFrame *sink_frame;
 
 	resample_t resample;
@@ -74,6 +75,13 @@ void mix_destroy(mix_t *mix) {
 	g_slice_free1(sizeof(*mix), mix);
 }
 
+void mix_set_channel_slots(mix_t *mix, unsigned int channel_slots) {
+	if(!mix)
+		return;
+	mix->channel_slots = channel_slots < 1 ? 1 : channel_slots;
+	ilog(LOG_DEBUG, "setting slots %i", mix->channel_slots);
+}
+
 
 static void mix_input_reset(mix_t *mix, unsigned int idx) {
 	mix->pts_offs[idx] = (uint64_t) -1LL;
@@ -82,48 +90,45 @@ static void mix_input_reset(mix_t *mix, unsigned int idx) {
 	mix->in_pts[idx] = 0;
 }
 
-unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int media_rec_slot, unsigned int slots) {
-	unsigned int next = 0;
-	bool slotmatch = false;
+unsigned int mix_get_index(mix_t *mix, void *ptr, unsigned int stream_channel_slot) {
 
-	while(slotmatch == false) {
+	ilog(LOG_DEBUG, "next index is set to %u for slot %u. channel slots for this mix are %u", mix->next_idx[stream_channel_slot], stream_channel_slot, mix->channel_slots);
 
-		// Find the next unused slot first
-		while(mix->input_ref[next] != NULL) {
-			next = next + 1;
-		}
-
-		ilog(LOG_DEBUG, "%i MOD %i == %i", next, slots, media_rec_slot);
-
-		if(next % slots == media_rec_slot)
-			slotmatch = true;
-		if(slotmatch == false)
-			next = next + 1;
+	if(mix->next_idx[stream_channel_slot] == mix_num_inputs+1) {
+		mix->next_idx[stream_channel_slot] = stream_channel_slot;
+		ilog(LOG_DEBUG, "first time use of slot %u - mix input index chosen is %u", stream_channel_slot, mix->next_idx[stream_channel_slot]);
+	} else {
+		mix->next_idx[stream_channel_slot] += mix->channel_slots;
+		ilog(LOG_DEBUG, "subsequent use of slot %u - mix input index chosen is %u", stream_channel_slot, mix->next_idx[stream_channel_slot]);
 	}
 
+	unsigned int next = mix->next_idx[stream_channel_slot];
+
 	if (next < mix_num_inputs) {
-		ilog(LOG_DEBUG, "Mix input slots available %i, slot requested %i, mix index chosen %i", slots, media_rec_slot, next);
 		// must be unused
 		mix->input_ref[next] = ptr;
 		return next;
 	}
 
+	ilog(LOG_DEBUG, "mix input index %u too high, cycling to find one to re-use", next);
+
 	// too many inputs - find one to re-use
 	struct timeval earliest = {0,};
 	next = 0;
 	for (unsigned int i = 0; i < mix_num_inputs; i++) {
-		if ((earliest.tv_sec == 0 || timeval_cmp(&earliest, &mix->last_use[i]) > 0) && i % slots == media_rec_slot) {
+		if ((earliest.tv_sec == 0 || timeval_cmp(&earliest, &mix->last_use[i]) > 0) &&
+			    i % mix->channel_slots == stream_channel_slot) {
 			next = i;
 			earliest = mix->last_use[i];
 		}
 	}
 
-	ilog(LOG_DEBUG, "Mix input slots available %i, slot requested %i, Re-using mix index %i", slots, media_rec_slot, next);
+	ilog(LOG_DEBUG, "requested slot is %u, Re-using mix input index #%u", stream_channel_slot, next);
 	mix_input_reset(mix, next);
 	mix->input_ref[next] = ptr;
+	mix->next_idx[stream_channel_slot] = next;
 	return next;
 }
-
 
 int mix_config(mix_t *mix, const format_t *format) {
 	const char *err;
@@ -241,6 +246,12 @@ mix_t *mix_new(void) {
 
 	for (unsigned int i = 0; i < mix_num_inputs; i++)
 		mix->pts_offs[i] = (uint64_t) -1LL;
+
+	for (unsigned int i = 0; i < mix_num_inputs; i++) {
+		// initialise with the first mixer channel to use for each slot. This is set to mix_num_inputs+1
+		// so that we can detect first use and also if the maximum use has been reached.
+		mix->next_idx[i] = mix_num_inputs+1;
+	}
 
 	return mix;
 }

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -10,7 +10,7 @@ mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *);
+unsigned int mix_get_index(mix_t *, void *, unsigned int media_rec_slot, unsigned int slots);
 
 
 #endif

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -8,9 +8,10 @@
 
 mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
+void mix_set_channel_slots(mix_t *mix, unsigned int channel_slots);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *, unsigned int media_rec_slot, unsigned int slots);
+unsigned int mix_get_index(mix_t *, void *, unsigned int stream_channel_slot);
 
 
 #endif

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -138,11 +138,10 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 	epoll_add(stream->fd, EPOLLIN, &stream->handler);
 }
 
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_rec_slot, unsigned int media_rec_slots) {
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int channel_slot) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
-	stream->media_rec_slot = media_rec_slot;
-	stream->media_rec_slots = media_rec_slots;
+	stream->channel_slot = channel_slot;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -141,7 +141,11 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int channel_slot) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
-	stream->channel_slot = channel_slot;
+
+	if(channel_slot > mix_num_inputs) {
+		ilog(LOG_ERR, "Channel slot %u is greater than the maximum number of inputs %u, setting to %u", channel_slot, mix_num_inputs, mix_num_inputs);
+	}
+	stream->channel_slot = channel_slot > mix_num_inputs ? mix_num_inputs : channel_slot;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -138,9 +138,11 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 	epoll_add(stream->fd, EPOLLIN, &stream->handler);
 }
 
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag) {
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_rec_slot, unsigned int media_rec_slots) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
+	stream->media_rec_slot = media_rec_slot;
+	stream->media_rec_slots = media_rec_slots;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 void stream_open(metafile_t *mf, unsigned long id, char *name);
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag);
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_rec_slot, unsigned int media_rec_slots);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
 void stream_close(stream_t *stream);
 void stream_free(stream_t *stream);

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 void stream_open(metafile_t *mf, unsigned long id, char *name);
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_rec_slot, unsigned int media_rec_slots);
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int channel_slot);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
 void stream_close(stream_t *stream);
 void stream_free(stream_t *stream);

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -57,8 +57,7 @@ struct stream_s {
 	handler_t handler;
 	unsigned int forwarding_on:1;
 	double start_time;
-	unsigned int media_rec_slot;
-	unsigned int media_rec_slots;
+	unsigned int channel_slot;
 };
 typedef struct stream_s stream_t;
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -57,6 +57,8 @@ struct stream_s {
 	handler_t handler;
 	unsigned int forwarding_on:1;
 	double start_time;
+	unsigned int media_rec_slot;
+	unsigned int media_rec_slots;
 };
 typedef struct stream_s stream_t;
 


### PR DESCRIPTION
…n be controlled when producing a mixed audio file

When a mixed wav file is created, the channels in the wav container are currently allocated in the same order as each SSRC is received, meaning it is impossible to know which channels have been allocated to the offer or answer side of the call. Furthermore if there is a reinvite or media file played, these are also allocated in the order that SSRC is received - so an "answer" could end up sharing a channel with an "offer" with no way of knowing this.

This patch allows you to specify how many channel slots should be allocated within the mixer, and allows you to then specify which slot is assigned to each media in the call (this will usually be 2 slots in total, slot 1 for answer, slot 2 for offer or vice versa).  

The mixer will then use up the slots as per these rules. So (assuming a MIX_MAX_INPUTS=4 limit in mix.h) channel 0,2 will be used for the offer and channel 1,3 will be used for the answer - subsequent SSRCs will rotate round and reuse 0,2 and 1,3 respectively.

If 3 slots are specified then slot 1 would use channels 0,3,6... Slot 2 would use channels 1,4,7... Slot 3 would use channels 2,5,8 assuming the MIX_MAX_INPUTS limits in mix.h allowed this.

If 0 or 1 slots are specified then channels will be used up as each SSRC is seen as per previous behaviour.

Note: I was unsure how to make/check defaults in call_interfaces.c so any pointers here would be appreciated. Also, all flags are set in the offer as it seems we can only guarantee this is available when the recording metafile is written - the answer may not yet exist.