### PR TITLE
Execute chmod and chown operations after file is opened

### DIFF
--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -26,7 +26,6 @@ static void meta_free(void *ptr) {
 	metafile_t *mf = ptr;
 
 	dbg("freeing metafile info for %s%s%s", FMT_M(mf->name));
-	output_close(mf, mf->mix_out, NULL, mf->discard);
 	mix_destroy(mf->mix);
 	db_close_call(mf);
 	g_string_chunk_free(mf->gsc);
@@ -82,6 +81,8 @@ static void meta_destroy(metafile_t *mf) {
 		mf->ssrc_hash = NULL;
 	}
 	db_close_call(mf);
+	output_close(mf, mf->mix_out, NULL, mf->discard);
+	mf->mix_out = NULL;
 }
 
 

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -341,6 +341,16 @@ got_fn:
 	if (av_ret)
 		goto err;
 
+	if (output_chmod)
+		if (chmod(output->filename, output_chmod))
+			ilog(LOG_WARN, "Failed to change file mode of '%s%s%s': %s",
+					FMT_M(output->filename), strerror(errno));
+					
+	if (output_chown != -1 || output_chgrp != -1)
+		if (chown(output->filename, output_chown, output_chgrp))
+			ilog(LOG_WARN, "Failed to change file owner/group of '%s%s%s': %s",
+					FMT_M(output->filename), strerror(errno));
+
 	if (flush_packets) {
 		output->fmtctx->flags |= AVFMT_FLAG_FLUSH_PACKETS;
 	}
@@ -373,15 +383,7 @@ static bool output_shutdown(output_t *output) {
 	if (output->fmtctx->pb) {
 		av_write_trailer(output->fmtctx);
 		avio_closep(&output->fmtctx->pb);
-		ret = true;
-		if (output_chmod)
-			if (chmod(output->filename, output_chmod))
-				ilog(LOG_WARN, "Failed to change file mode of '%s%s%s': %s",
-						FMT_M(output->filename), strerror(errno));
-		if (output_chown != -1 || output_chgrp != -1)
-			if (chown(output->filename, output_chown, output_chgrp))
-				ilog(LOG_WARN, "Failed to change file owner/group of '%s%s%s': %s",
-						FMT_M(output->filename), strerror(errno));
+		ret = true;		
 	}
 	avformat_free_context(output->fmtctx);
 


### PR DESCRIPTION
- Relocated chmod and chown operations from output_shutdown to output_config.
- Ensures file permissions and ownership are set immediately after file is opened.