### PR TITLE
Reject OSRTP answer when not offered

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2359,8 +2359,12 @@ static void __update_media_protocol(struct call_media *media, struct call_media 
 						media->protocol = NULL; // reject
 				}
 				// pass through any other protocol change?
-				else if (!flags->protocol_accept)
-					;
+				else if (!flags->protocol_accept) {
+					if (media->protocol && sp->protocol && !media->protocol->osrtp && sp->protocol->osrtp) {
+						ilog(LOG_WARNING, "Ignore OSRTP answer since this was not offered");
+						other_media->protocol = media->protocol;
+					}
+				}
 				else
 					media->protocol = NULL;
 			}


### PR DESCRIPTION
This issue has been discussed in the mailing list:
https://groups.google.com/g/rtpengine/c/pFh2T2Nucnw

You have a call where OSRTP is offered from caller, but rejected/ignored by rtpengine.
Later a reINVITE from callee is sent without without crypto attributes towards caller.
Caller then responds with crypto attributes and those are accepted by rtpengine.
Now RTP will stop since it can not decrypt det non-encrypted traffic from caller and/or crypto attributes are not fully set, so it will fail sending encrypted traffic back.

Behaviour is observed for Aastra/Mitel phones and Baresip with "mediaenc=srtp".