### PR TITLE
Do not kernelize rtp streams without confirmed SSRC

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -2143,7 +2143,7 @@ static void media_packet_rtp_in(struct packet_handler_ctx *phc)
 
 	const char *unkern = NULL;
 
-	if (G_LIKELY(!phc->rtcp && !rtp_payload(&phc->mp.rtp, &phc->mp.payload, &phc->s))) {
+	if (G_LIKELY(!phc->rtcp && (phc->mp.rtp?1:!rtp_payload(&phc->mp.rtp, &phc->mp.payload, &phc->s)))) {
 		unkern = __stream_ssrc_in(phc->in_srtp, phc->mp.rtp->ssrc, &phc->mp.ssrc_in,
 				phc->mp.media->monologue->ssrc_hash);
 
@@ -2315,6 +2315,19 @@ static bool media_packet_address_check(struct packet_handler_ctx *phc)
 					"peer address confirmation purposes",
 					FMT_M(endpoint_print_buf(&phc->mp.fsin)));
 			goto out;
+		} else if(proto_is_rtp(phc->mp.media->protocol)) {
+			if(rtp_payload(&phc->mp.rtp, &phc->mp.payload, &phc->s) != 0) {
+				ilog(LOG_INFO | LOG_FLAG_LIMIT, "Ignoring invalid RTP packet from %s%s%s for "
+						"peer address confirmation purposes",
+						FMT_M(endpoint_print_buf(&phc->mp.fsin)));
+				goto out;
+			}
+			if(!phc->mp.rtp->ssrc) {
+				ilog(LOG_INFO | LOG_FLAG_LIMIT, "Ignoring RTP packet with zero SSRC from %s%s%s for "
+						"peer address confirmation purposes",
+						FMT_M(endpoint_print_buf(&phc->mp.fsin)));
+				goto out;
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi !

The story is - caller is a Cisco Webex video сonference device (videocodec).
Cisco device initiates a call, opens audio/video streams and also offers screen sharing as H.264 video, screen sharing can start optionally at any time during the call. The rtpengine is media proxy at the perimeter, callee is somewhere in the public and rtpengine converts streams from Cisco RTP to SRTP for remote party.

Now the issue - screen sharing stream randomly stops working after some time in a call, audio and video streams work properly.
During debugging we noticed that if screen sharing starts almost at the beginning of the call it works fine.
Screen sharing start time in working scenario correlates with learning phase interval, so we tried to turn off kernelization, after that the screen sharing issues were completely gone.

After more debugging, we found out that rtpengine kernelizes screen sharing stream with empty SSRC list. 
It happens because Cisco in the beginning of media stream sends several packets which are detected by rtpengine as RTP V1 (probably for the NAT traversal).These packets are ignored by rtpengine but affect the decision to kernelize stream. What happens next - because stream to caller is SRTP, kernel module tries to track ROC. While ROC is zero stream functions as expected, but once ROC gets incremented - the stream becomes broken. We see two cases of this - first is FEC, it works as separate SSRC in the same stream so ROC must be tracked separately for each SSRC, in our case rtpengine does not distingush them and incrementation of ROC for one SSRC immediately breaks the second one as SRTP authentication header for it becomes invalid. Second is the session timer in signaling, which fires re-INVITE and unkernelizes then kernelizes stream again, once screen sharing stream is unkenelized rtpengine reports a “new ingress SSRC” and, as we assume, clears ROC for the stream to zero, it also breaks SRTP authentication headers for SSRC where ROC was incremented at least once.

So i think the solution in this case - do not kernelize RTP stream without valid SSRC, this PR adds a strict check for that in learning phase. We tested changes with version 11.5, but we think the changes will work as expected in version 12 as well. 