### PR TITLE
Added decoder mix "slots" concept, so that the desired wav channel ca…

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2630,6 +2630,9 @@ static void __call_monologue_init_from_flags(struct call_monologue *ml, struct c
 
 	call->last_signal = rtpe_now.tv_sec;
 	call->deleted = 0;
+	call->media_rec_slots = (flags->media_rec_slots > 0 && call->media_rec_slots == 0)
+								? flags->media_rec_slots
+								: call->media_rec_slots;
 
 	// consume session attributes
 	t_queue_clear_full(&ml->sdp_attributes, sdp_attr_free);
@@ -2884,6 +2887,12 @@ static void __media_init_from_flags(struct call_media *other_media, struct call_
 			media->desired_family = other_media->desired_family;
 		if (sp->desired_family)
 			media->desired_family = sp->desired_family;
+	}
+
+	if (flags->opmode == OP_OFFER) {
+		ilog(LOG_DEBUG, "setting other slot to %u, setting slot to %u", flags->media_rec_slot_offer, flags->media_rec_slot_answer);
+		other_media->media_rec_slot = flags->media_rec_slot_offer;
+		media->media_rec_slot = flags->media_rec_slot_answer;
 	}
 
 	/* bandwidth */

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1759,6 +1759,18 @@ void call_ng_main_flags(const ng_parser_t *parser, str *key, parser_arg value, h
 		case CSH_LOOKUP("recording file"):
 			out->recording_file = s;
 			break;
+		case CSH_LOOKUP("recording-media-slot-offer"):
+			// This needs to be > 0
+			//out->media_rec_slot_offer = bencode_get_integer_str(value, out->media_rec_slot_offer);
+			out->media_rec_slot_offer = parser->get_int_str(value, out->media_rec_slot_offer);
+		break;
+		case CSH_LOOKUP("recording-media-slot-answer"):
+			// This needs to be > 0
+			out->media_rec_slot_answer = parser->get_int_str(value, out->media_rec_slot_answer);
+		break;
+		case CSH_LOOKUP("recording-media-slots"):
+			out->media_rec_slots = parser->get_int_str(value, out->media_rec_slots);
+		break;
 		case CSH_LOOKUP("passthrough"):
 		case CSH_LOOKUP("passthru"):
 			switch (__csh_lookup(&s)) {

--- a/include/call.h
+++ b/include/call.h
@@ -480,6 +480,7 @@ struct call_media {
 	struct dtls_fingerprint fingerprint;			/* as received */
 	const struct dtls_hash_func *fp_hash_func;		/* outgoing */
 	str			tls_id;
+	unsigned int			media_rec_slot;
 
 	packet_stream_q		streams;			/* normally RTP + RTCP */
 	endpoint_map_q		endpoint_maps;
@@ -751,6 +752,7 @@ struct call {
 	enum block_dtmf_mode	block_dtmf;
 
 	atomic64		call_flags;
+	unsigned int media_rec_slots;
 };
 
 

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -118,6 +118,9 @@ struct sdp_ng_flags {
 	int trigger_end_digits;
 	int trigger_end_ms;
 	int dtmf_delay;
+	int media_rec_slot_offer;
+	int media_rec_slot_answer;
+	int media_rec_slots;
 	int repeat_times;
 	str file;
 	str blob;

--- a/recording-daemon/decoder.c
+++ b/recording-daemon/decoder.c
@@ -115,7 +115,7 @@ static int decoder_got_frame(decoder_t *dec, AVFrame *frame, void *sp, void *dp)
 	if (metafile->mix_out) {
 		dbg("adding packet from stream #%lu to mix output", stream->id);
 		if (G_UNLIKELY(deco->mixer_idx == (unsigned int) -1))
-			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media_sdp_id);
+			deco->mixer_idx = mix_get_index(metafile->mix, ssrc, stream->media_sdp_id, stream->channel_slot);
 		format_t actual_format;
 		if (output_config(metafile->mix_out, &dec->dest_format, &actual_format))
 			goto no_mix_out;

--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -110,12 +110,14 @@ static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *cont
 // mf is locked
 static void meta_stream_details(metafile_t *mf, unsigned long snum, char *content) {
 	dbg("stream %lu details %s", snum, content);
-	unsigned int tag, media, tm, cmp, media_sdp_id;
+	unsigned int tag, media, tm, cmp, media_sdp_id, media_rec_slot, media_rec_slots;
 	uint64_t flags;
-	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-SDP-ID %i",
-				&tag, &media, &tm, &cmp, &flags, &media_sdp_id) != 6)
+	if (sscanf_match(content, "TAG %u MEDIA %u TAG-MEDIA %u COMPONENT %u FLAGS %" PRIu64 " MEDIA-SDP-ID %i MEDIA-REC-SLOT %i MEDIA-REC-SLOTS %i",
+				&tag, &media, &tm, &cmp, &flags, &media_sdp_id, &media_rec_slot, &media_rec_slots) != 8)
 		return;
-	stream_details(mf, snum, tag, media_sdp_id);
+
+	mix_set_channel_slots(mf->mix, media_rec_slots);
+	stream_details(mf, snum, tag, media_sdp_id, media_rec_slot-1);
 }
 
 

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -8,8 +8,9 @@
 
 mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
+void mix_set_channel_slots(mix_t *mix, unsigned int);
 int mix_config(mix_t *, const format_t *format);
 int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *, unsigned int);
+unsigned int mix_get_index(mix_t *, void *, unsigned int, unsigned int);
 #endif
 

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -138,10 +138,14 @@ void stream_open(metafile_t *mf, unsigned long id, char *name) {
 	epoll_add(stream->fd, EPOLLIN, &stream->handler);
 }
 
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id) {
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id, unsigned int channel_slot) {
 	stream_t *stream = stream_get(mf, id);
 	stream->tag = tag;
 	stream->media_sdp_id = media_sdp_id;
+	if(channel_slot > mix_num_inputs) {
+		ilog(LOG_ERR, "Channel slot %u is greater than the maximum number of inputs %u, setting to %u", channel_slot, mix_num_inputs, mix_num_inputs);
+	}
+	stream->channel_slot = channel_slot > mix_num_inputs ? mix_num_inputs : channel_slot;
 }
 
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on) {

--- a/recording-daemon/stream.h
+++ b/recording-daemon/stream.h
@@ -4,7 +4,7 @@
 #include "types.h"
 
 void stream_open(metafile_t *mf, unsigned long id, char *name);
-void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id);
+void stream_details(metafile_t *mf, unsigned long id, unsigned int tag, unsigned int media_sdp_id, unsigned int channel_slot);
 void stream_forwarding_on(metafile_t *mf, unsigned long id, unsigned int on);
 void stream_sdp_label(metafile_t *mf, unsigned long id, unsigned long *label);
 void stream_close(stream_t *stream);

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -58,6 +58,7 @@ struct stream_s {
 	unsigned int forwarding_on:1;
 	double start_time;
 	unsigned int media_sdp_id;
+	unsigned int channel_slot;
 };
 typedef struct stream_s stream_t;
 


### PR DESCRIPTION
…n be controlled when producing a mixed audio file

When a mixed wav file is created, the channels in the wav container are currently allocated in the same order as each SSRC is received, meaning it is impossible to know which channels have been allocated to the offer or answer side of the call. Furthermore if there is a reinvite or media file played, these are also allocated in the order that SSRC is received - so an "answer" could end up sharing a channel with an "offer" with no way of knowing this.

This patch allows you to specify how many channel slots should be allocated within the mixer, and allows you to then specify which slot is assigned to each media in the call (this will usually be 2 slots in total, slot 1 for answer, slot 2 for offer or vice versa).

Ported from https://github.com/sipwise/rtpengine/pull/1852