### PR TITLE
Ensure (AEAD) req and copy pointers don't leak memory

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5755,6 +5755,7 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 		// make copy of payload in case the decyption clobbers it
 		if (!copy)
 			copy = kmalloc(r->payload_len, GFP_ATOMIC);
+			
 		if (copy)
 			memcpy(copy, r->payload, r->payload_len);
 

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5749,7 +5749,6 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 			return -ENOMEM;
 		}
 		if (IS_ERR(req)) {
-			aead_request_free(req);
 			if (copy)
 				kfree(copy);
 			return PTR_ERR(req);

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5753,7 +5753,8 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 		sg_set_buf(&sg[1], r->payload, r->payload_len);
 
 		// make copy of payload in case the decyption clobbers it
-		copy = kmalloc(r->payload_len, GFP_ATOMIC);
+		if (!copy)
+			copy = kmalloc(r->payload_len, GFP_ATOMIC);
 		if (copy)
 			memcpy(copy, r->payload, r->payload_len);
 

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5749,6 +5749,7 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 			return -ENOMEM;
 		}
 		if (IS_ERR(req)) {
+			aead_request_free(req);
 			if (copy)
 				kfree(copy);
 			return PTR_ERR(req);


### PR DESCRIPTION
In `srtp_decrypt_aes_gcm` there are multiple places than can leak memory.

`req` pointer can leak when `IS_ERR` is true.
`copy` pointer is allocated on each iteration loop but it is free-ed only once outside the loop. If the loop runs more than once and it performs an early exit on `req` checks or it simply runs multiple times, the `copy` pointer will leak.