### PR TITLE
Clamp the stream max packets for intercept streams to a value between 0 and stream_packets_list_limit

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5755,6 +5755,7 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 		// make copy of payload in case the decyption clobbers it
 		if (!copy)
 			copy = kmalloc(r->payload_len, GFP_ATOMIC);
+			
 		if (copy)
 			memcpy(copy, r->payload, r->payload_len);
 

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5749,7 +5749,6 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 			return -ENOMEM;
 		}
 		if (IS_ERR(req)) {
-			aead_request_free(req);
 			if (copy)
 				kfree(copy);
 			return PTR_ERR(req);

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5753,7 +5753,8 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 		sg_set_buf(&sg[1], r->payload, r->payload_len);
 
 		// make copy of payload in case the decyption clobbers it
-		copy = kmalloc(r->payload_len, GFP_ATOMIC);
+		if (!copy)
+			copy = kmalloc(r->payload_len, GFP_ATOMIC);
 		if (copy)
 			memcpy(copy, r->payload, r->payload_len);
 

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -5749,6 +5749,7 @@ static int srtp_decrypt_aes_gcm(struct re_crypto_context *c,
 			return -ENOMEM;
 		}
 		if (IS_ERR(req)) {
+			aead_request_free(req);
 			if (copy)
 				kfree(copy);
 			return PTR_ERR(req);

--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -3386,7 +3386,7 @@ not_found:
 
 	info->idx.stream_idx = idx;
 	memcpy(&stream->info, info, sizeof(call->info));
-	if (!stream->info.max_packets)
+	if ((!stream->info.max_packets) || (stream->info.max_packets > stream_packets_list_limit))
 		stream->info.max_packets = stream_packets_list_limit;
 
 	list_add(&stream->call_entry, &call->streams); /* new ref here */


### PR DESCRIPTION
It looks like the `info.max_packets` is corrupted here and != 0. This means that it is not capped to the `stream_packets_list_limit` value. I've found that its value (not sure if on each restart) is always `32647` which leads to a giant memory usage with many recorded calls.

This patch keeps the `==0` check and adds another upper boundary check to make sure we cap it to the max value specified in the `stream_packets_list_limit` kernel parameter (10 by default).