### PR TITLE
clamp the intercept stream max_packets between 0 and the value specif…

### DIFF
--- a/kernel-module/xt_RTPENGINE.c
+++ b/kernel-module/xt_RTPENGINE.c
@@ -3386,7 +3386,7 @@ not_found:
 
 	info->idx.stream_idx = idx;
 	memcpy(&stream->info, info, sizeof(call->info));
-	if (!stream->info.max_packets)
+	if ((!stream->info.max_packets) || (stream->info.max_packets > stream_packets_list_limit))
 		stream->info.max_packets = stream_packets_list_limit;
 
 	list_add(&stream->call_entry, &call->streams); /* new ref here */


### PR DESCRIPTION
It looks like the `info.max_packets` is corrupted here and != 0. This means that it is not capped to the `stream_packets_list_limit` value. I've found that its value (not sure if on each restart) is always `32647` which leads to a giant memory usage with many recorded calls.

This patch keeps the `==0` check and adds another upper boundary check to make sure we cap it to the max value specified in the `stream_packets_list_limit` kernel parameter (10 by default).