### PR TITLE
media_socket.c: check for NULL payload_types passed to kernelize_one

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -1521,7 +1521,7 @@ static const char *kernelize_one(struct rtpengine_target_info *reti, GQueue *out
 		}
 	}
 
-	if (reti->rtp && sinks && sinks->length) {
+	if (reti->rtp && sinks && sinks->length && payload_types) {
 		GList *l;
 		struct rtp_stats *rs;
 


### PR DESCRIPTION
under normal circumstances, the rtp sink enters this function first and updates the reti->local.family var to AF_INET so that when the function is called for an rtcp sink, it exits the function early. However, if media is being blocked the rtcp sink is the first to enter the function and does so with a NULL payload type. this NULL check is therefore required to prevent a sefgault on the call to `assert`.