### PR TITLE
Fix EL build errors

### DIFF
--- a/el/rtpengine-8-x86_64.cfg
+++ b/el/rtpengine-8-x86_64.cfg
@@ -17,7 +17,7 @@ enabled=1
 
 [copr:copr.fedorainfracloud.org:beaveryoga:broadvoice]
 name=Copr repo for broadvoice owned by beaveryoga
-baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-8-$basearch/
+baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-$releasever-$basearch/
 skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/pubkey.gpg
@@ -27,7 +27,7 @@ enabled_metadata=1
 """
 
 config_opts['chroot_additional_packages'] = "perl-interpreter libdb-devel gdbm-devel libuuid-devel speexdsp-devel"
-config_opts['chroot_additional_packages'] += " spandsp3-devel perl-podlators pandoc"
+config_opts['chroot_additional_packages'] += " spandsp3-devel perl-podlators pandoc libatomic"
 
 config_opts['root'] = 'rtpengine-8-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/el/rtpengine-9-x86_64.cfg
+++ b/el/rtpengine-9-x86_64.cfg
@@ -17,7 +17,7 @@ enabled=1
 
 [copr:copr.fedorainfracloud.org:beaveryoga:broadvoice]
 name=Copr repo for broadvoice owned by beaveryoga
-baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-8-$basearch/
+baseurl=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/epel-$releasever-$basearch/
 skip_if_unavailable=True
 gpgcheck=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/beaveryoga/broadvoice/pubkey.gpg
@@ -28,7 +28,7 @@ enabled_metadata=1
 
 config_opts['chroot_additional_packages'] = "perl-interpreter libdb-devel gdbm-devel libuuid-devel speexdsp-devel"
 config_opts['chroot_additional_packages'] += " spandsp3-devel perl-podlators pandoc"
-config_opts['chroot_additional_packages'] += " gcc make autoconf automake gcc-c++ libtool"
+config_opts['chroot_additional_packages'] += " gcc make autoconf automake gcc-c++ libtool libatomic"
 
 config_opts['root'] = 'rtpengine-9-x86_64'
 config_opts['target_arch'] = 'x86_64'

--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -34,6 +34,7 @@ BuildRequires:	libpcap-devel libevent-devel json-glib-devel
 BuildRequires:	mosquitto-devel
 BuildRequires:	gperf perl-IPC-Cmd
 BuildRequires:	perl-podlators
+BuildRequires:	libatomic
 BuildRequires:	pkgconfig(libwebsockets)
 BuildRequires:	pkgconfig(spandsp)
 BuildRequires:	pkgconfig(opus)


### PR DESCRIPTION
* Added libatomic to the el/ build dependencies. This was required since commit 741f6ac when -latomic was added to lib/common.Makefile
* Changed link to the copr repo with spandsp3. There is seperate repo for EL9 now.