### PR TITLE
LTS mr11.5.1 - workaround for RPM packaging EL8/GCC 8.5

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -21,6 +21,10 @@ BuildRequires:	perl-podlators
 BuildRequires:	pkgconfig(libwebsockets)
 BuildRequires:	pkgconfig(spandsp)
 BuildRequires:	pkgconfig(opus)
+%if 0%{?rhel} == 8
+# LTS mr11.5.1 cannot build with gcc 8.5
+BuildRequires: gcc-toolset-13
+%endif
 Requires(pre):	shadow-utils
 
 %if 0%{?with_transcoding} > 0
@@ -96,6 +100,10 @@ and decodes them into an audio format that can be listened to.
 
 
 %build
+%if 0%{?rhel} == 8
+# LTS mr11.5.1 cannot build with gcc 8.5
+. /opt/rh/gcc-toolset-13/enable
+%endif
 %if 0%{?with_transcoding} > 0
 cd daemon
 RTPENGINE_VERSION="\"%{version}-%{release}\"" make


### PR DESCRIPTION
- LTS mr11.5.1 doesn't build RPM using  system GCC(8.5) on EL8; segmentation fault in ld step
- add a workaround for using GCC 13 when building RPM

Addresses: #1886

Note: LTS mr12.5.1 does build RPM using system GCC

Update: this patch only touches `el/rtpengine.spec` so should not have affected the debian sid build. The debian sid error looks like a GCC 14 thing.