### PR TITLE
rpm/el8: needs gcc-toolset-13-libatomic-devel for -latomic usage

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -40,7 +40,7 @@ BuildRequires:	pkgconfig(spandsp)
 BuildRequires:	pkgconfig(opus)
 %if 0%{?rhel} == 8
 # LTS mr11.5.1 cannot build with gcc 8.5
-BuildRequires: gcc-toolset-13
+BuildRequires: gcc-toolset-13 gcc-toolset-13-libatomic-devel
 %endif
 Requires(pre):	shadow-utils
 %if 0%{?rhel} >= 8


### PR DESCRIPTION
With `-latomic` the build on EL8 with gcc-toolset-13 (originally to workaround some mr11.5 build) needs the package `gcc-toolset-13-libatomic-devel`.