### PR TITLE
fix calling redis_delete when call is not persisted to db

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -4005,7 +4005,8 @@ void call_destroy(call_t *c) {
 	statistics_update_ip46_inc_dec(c, CMC_DECREMENT);
 	statistics_update_foreignown_dec(c);
 
-	redis_delete(c, rtpe_redis_write);
+	if (c->redis_hosted_db >= 0)
+		redis_delete(c, rtpe_redis_write);
 
 	__call_iterator_remove(c);
 


### PR DESCRIPTION
Fixes a corner case that happens when trying to delete a call created with ng offer and no-redis-update flag and for which no ng answer was received. In such cases, one would receive warning messages from Redis "ERR DB index is out of range".

What happens is that on call creation redis_hosted_db defaults to -1. This value is changed when writing to Redis, but the writing is not done for a ng offer with no-redis-update.

Kudos go to Pawel Kuzak.