### PR TITLE
Segmentation fault - Skip tag retrieval if missing in monologue stats

### DIFF
--- a/daemon/mqtt.c
+++ b/daemon/mqtt.c
@@ -161,8 +161,10 @@ static void mqtt_call_stats(call_t *call, JsonBuilder *json) {
 
 
 static void mqtt_monologue_stats(struct call_monologue *ml, JsonBuilder *json) {
-	json_builder_set_member_name(json, "tag");
-	glib_json_builder_add_str(json, &ml->tag);
+	if (ml->tag.len) {
+		json_builder_set_member_name(json, "tag");
+		glib_json_builder_add_str(json, &ml->tag);
+	}
 
 	if (ml->label.len) {
 		json_builder_set_member_name(json, "label");


### PR DESCRIPTION
RTPengine version 13.0.1.3.

Segmentation fault can stop rtpengine process when call is using generated early media and monologue tag is missing.

Reproducible by calling sip client with generated early media SIP 180 while rtpengine generated monologue MQTT report before callee picks up the call.