### PR TITLE
Prevent warning logs when recording-method is pcap #2

### DIFF
--- a/daemon/recording.c
+++ b/daemon/recording.c
@@ -835,6 +835,9 @@ static int vappend_meta_chunk(struct recording *recording, const char *buf, unsi
 		const char *label_fmt, va_list ap)
 {
 	struct iovec iov;
+	if (!recording->proc.meta_filepath)
+		return -1;
+
 	iov.iov_base = (void *) buf;
 	iov.iov_len = buflen;
 


### PR DESCRIPTION
If recording-method is pcap, then proc is zero-initialized, so meta_filepath is empty. This shows many logs such as:

[core] Failed to open recording metadata file '(null)' for writing: Bad address

Prevent them by returning earlier.

Fixes #1889 for real this time.

Amends commit 759fd72dc6866b2c89eddd8940bb4b2040699f23.