### PR TITLE
some fixes when using delay-buffer + block-media + play-media

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -5207,7 +5207,7 @@ static void media_stop(struct call_media *m) {
 		return;
 	t38_gateway_stop(m->t38_gateway);
 	audio_player_stop(m);
-	codec_handlers_stop(&m->codec_handlers_store, NULL);
+	codec_handlers_stop(&m->codec_handlers_store, NULL, false);
 	rtcp_timer_stop(&m->rtcp_timer);
 	mqtt_timer_stop(&m->mqtt_timer);
 }

--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -937,6 +937,10 @@ struct codec_handler *codec_handler_make_media_player(const rtp_payload_type *sr
 	struct codec_handler *h = codec_handler_make_playback(src_pt, dst_pt, last_ts, media, ssrc, codec_set);
 	if (!h)
 		return NULL;
+
+	ilogs(transcoding, LOG_DEBUG, "Disabling clock skew calculation for media playback handler");
+	h->ssrc_handler->csch.is_media_playback = true;
+
 	if (audio_player_is_active(media)) {
 		h->packet_decoded = packet_decoded_audio_player;
 		if (!audio_player_pt_match(media, dst_pt))
@@ -2485,7 +2489,9 @@ void codec_output_rtp(struct media_packet *mp, struct codec_scheduler *csch,
 
 	ts_diff_us = p->ttq_entry.when - rtpe_now;
 
-	csch->output_skew = csch->output_skew * 15 / 16 + ts_diff_us / 16;
+	if (!csch->is_media_playback)
+		csch->output_skew = csch->output_skew * 15 / 16 + ts_diff_us / 16;
+
 	if (csch->output_skew > 50000 && ts_diff_us > 10000) { // arbitrary value, 50 ms, 10 ms shift
 		ilogs(transcoding, LOG_DEBUG, "Steady clock skew of %li.%01li ms detected, shifting send timer back by 10 ms",
 			csch->output_skew / 1000,

--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -2703,7 +2703,11 @@ static tc_code packet_dtmf(struct codec_ssrc_handler *ch, struct codec_ssrc_hand
 
 	bool do_blocking = block_dtmf == BLOCK_DTMF_DROP;
 
-	if (packet->payload->len >= sizeof(struct telephone_event_payload)) {
+	if (is_dtmf_replace_mode(block_dtmf) && !handler_silence_block(packet->handler, mp)) {
+		 // don't send transcoded DTMF audio during media blocking");
+		do_blocking = true;
+	}
+	else if (packet->payload->len >= sizeof(struct telephone_event_payload)) {
 		struct telephone_event_payload *dtmf = (void *) packet->payload->s;
 		struct codec_handler *h = input_ch->handler;
 		// fudge up TS and duration values
@@ -2837,7 +2841,11 @@ static int __handler_func_supplemental(struct codec_handler *h, struct media_pac
 }
 static int handler_func_dtmf(struct codec_handler *h, struct media_packet *mp) {
 	// DTMF input - can we do DTMF output?
-	if (h->dtmf_payload_type == -1)
+
+	// handler_func_transcode will return immediately if we're blockinh media, which means
+	// the DTMF event won't be processed for log-dtmf etc. So, if media is being blocked,
+	// let it run through packet_dtmf, which will process it and then drop it
+	if (h->dtmf_payload_type == -1 && handler_silence_block(h, mp))
 		return handler_func_transcode(h, mp);
 
 	return __handler_func_supplemental(h, mp, packet_dtmf, packet_dtmf_dup);

--- a/daemon/media_player.c
+++ b/daemon/media_player.c
@@ -1637,7 +1637,7 @@ const char * call_play_media_for_ml(struct call_monologue *ml,
 {
 #ifdef WITH_TRANSCODING
 	/* if mixing is enabled, codec handlers of all sources must be updated */
-	codec_update_all_source_handlers(ml, flags);
+	codec_update_all_source_handlers(ml, flags, true);
 
 	/* this starts the audio player if needed */
 	update_init_monologue_subscribers(ml, OP_PLAY_MEDIA);
@@ -1670,7 +1670,7 @@ long long call_stop_media_for_ml(struct call_monologue *ml)
 #ifdef WITH_TRANSCODING
 	long long ret = media_player_stop(ml->player);
 	/* restore to non-mixing if needed */
-	codec_update_all_source_handlers(ml, NULL);
+	codec_update_all_source_handlers(ml, NULL, false);
 	update_init_monologue_subscribers(ml, OP_STOP_MEDIA);
 	/* mark MoH as already not used (it can be unset now) */
 	ml->player->opts.moh = 0;
@@ -2016,7 +2016,7 @@ static void media_player_run(void *ptr) {
 		if (mp->opts.block_egress)
 			MEDIA_CLEAR(mp->media, BLOCK_EGRESS);
 
-		codec_update_all_source_handlers(mp->media->monologue, NULL);
+		codec_update_all_source_handlers(mp->media->monologue, NULL, false);
 		update_init_monologue_subscribers(mp->media->monologue, OP_PLAY_MEDIA);
 
 		rwlock_unlock_w(&call->master_lock);

--- a/include/codec.h
+++ b/include/codec.h
@@ -106,6 +106,7 @@ struct codec_scheduler {
 	int64_t first_send;
 	unsigned long first_send_ts;
 	long output_skew;
+	bool is_media_playback; // used to track media playback so we can skip skew calculation
 };
 
 struct transcode_config {

--- a/include/codec.h
+++ b/include/codec.h
@@ -156,7 +156,7 @@ struct codec_handler *codec_handler_make_dummy(const rtp_payload_type *dst_pt, s
 		str_case_value_ht codec_set);
 void codec_calc_jitter(struct ssrc_entry_call *, unsigned long ts, unsigned int clockrate, int64_t);
 void codec_update_all_handlers(struct call_monologue *ml);
-void codec_update_all_source_handlers(struct call_monologue *ml, const sdp_ng_flags *flags);
+void codec_update_all_source_handlers(struct call_monologue *ml, const sdp_ng_flags *flags, bool clear_delay_buffer);
 
 struct codec_store_args {
 	str_case_value_ht codec_set;
@@ -228,6 +228,9 @@ struct chu_args {
 	const struct stream_params *sp;
 	bool allow_asymmetric;
 	bool reset_transcoding;
+	// when false (default if not passed) the delay buffer is flushed as normal
+	// used by play-media to ensure media packets aren't sent alongside delayed packets
+	bool clear_delay_buffer;
 };
 #define codec_handlers_update(r, s, ...) \
 	__codec_handlers_update(r, s, (struct chu_args) {__VA_ARGS__})
@@ -246,7 +249,7 @@ uint64_t codec_encoder_pts(struct codec_ssrc_handler *ch, struct ssrc_entry_call
 void codec_decoder_skip_pts(struct codec_ssrc_handler *ch, uint64_t);
 uint64_t codec_decoder_unskip_pts(struct codec_ssrc_handler *ch);
 void codec_tracker_update(struct codec_store *, struct codec_store *);
-void codec_handlers_stop(codec_handlers_q *, struct call_media *sink);
+void codec_handlers_stop(codec_handlers_q *, struct call_media *sink, bool clear_delay_buffer);
 
 
 void packet_encoded_packetize(AVPacket *pkt, struct codec_ssrc_handler *ch, struct media_packet *mp,


### PR DESCRIPTION
when media playback happens, all packets get scheduled at the same time with a send time in the future. however, this results in the output_skew calculation triggering an unnecessary shift in the send timer, which can cause choppy playback