### PR TITLE
Feat: early confirmation of heuristic endpoint-learning

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -2563,6 +2563,10 @@ static bool media_packet_address_check(struct packet_handler_ctx *phc)
 				break;
 		}
 
+		// confirm endpoint, if matches address advertised in SDP
+		if (idx == 0)
+			goto confirm_now;
+
 		// finally, if there has been a better match and if strict-source is set,
 		// drop this packet
 		if (PS_ISSET(phc->mp.stream, STRICT_SOURCE) && matched_idx < idx) {


### PR DESCRIPTION
When using the `heuristic` endpoint learning algo, confirm the endpoint immediately if it matches the address advertised in the SDP. This gives a slight performance bump to the `heuristic` algo as it doesn't need to wait the full 3 seconds if it receives a packet from the IP:Port advertised in the SDP.

In cases where the client is properly advertising its IP:Port in the SDP, this change makes the performance more in-line with the `immediate` algo.