### PR TITLE
EL RPM fixes

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -198,6 +198,8 @@ install -D -p -m644 etc/%{binname}-recording.conf \
 ## DKMS module source install
 install -D -p -m644 kernel-module/Makefile \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/Makefile
+install -D -p -m755 kernel-module/gen-rtpengine-kmod-flags \
+	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/gen-rtpengine-kmod-flags
 install -D -p -m644 kernel-module/xt_RTPENGINE.c \
 	 %{buildroot}%{_usrsrc}/%{name}-%{version}-%{release}/xt_RTPENGINE.c
 install -D -p -m644 kernel-module/xt_RTPENGINE.h \


### PR DESCRIPTION
1. Syntax error in the spec file, `if` instead of `%if`, rpmbuild fails.
2. Service unit with type=notify requires the service to be built with systemd support, fixed by adding a BuildRequires dependency.
3. DKMS module fails to build because of missing `gen-rtpengine-kmod-flags`, fixed by adding the file to the package.