### PR TITLE
el: rpm spec file improvements

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -61,7 +61,7 @@ Requires(pre):	ffmpeg-libs
 Requires:	perl-Config-Tiny
 Requires:	nc
 # Remain compat with other installations
-Provides:	ngcp-rtpengine = %{version}-%{release}
+Provides:	rtpengine = %{version}-%{release}
 
 %description
 The Sipwise NGCP rtpengine is a proxy for RTP traffic and other UDP based


### PR DESCRIPTION
Here two improvements
```
commit b06411a58ed7dc9bca3ea0f45167fb2c078c1ed9 (HEAD -> master, origin/master, origin/HEAD)
Author: Sergey Safarov <s.safarov@anycast-lb.net>
Date:   Tue Sep 2 12:03:04 2025 +0300

    el: Provides "ngcp-rtpengine" do not required because added
    as package name. Added Provides "rtpengine".

commit dd3009741a3783876c9dfe333b626bd4ef35f09c
Author: Sergey Safarov <s.safarov@anycast-lb.net>
Date:   Tue Sep 2 11:56:35 2025 +0300

    el: updated GitHub sources download URL
    
    This allow automaticaly download when added
    --undefine=_disable_source_fetch options
    
    Example
    rpmbuild -ba --undefine=_disable_source_fetch rtpengine.spec
```
If you'd like, I can remove `Provides` from the top commit.