### PR TITLE
recording - use the SSRC as the key for the mixer input_ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .*.sw?
 *.strhash.c
 docs/_*
+config.mk
+/.idea

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1750,7 +1750,8 @@ static void call_ng_main_flags(sdp_ng_flags *out, str *key, bencode_item_t *valu
 			//out->media_rec_slot_answer = parser->get_int_str(value, out->media_rec_slot_answer);
 		break;
 		case CSH_LOOKUP("recording-media-slots"):
-			out->media_rec_slots = parser->get_int_str(value, out->media_rec_slots);
+			out->media_rec_slots = bencode_get_integer_str(value, out->media_rec_slots);
+			//out->media_rec_slots = parser->get_int_str(value, out->media_rec_slots);
 		break;
 		case CSH_LOOKUP("passthrough"):
 		case CSH_LOOKUP("passthru"):

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1739,6 +1739,19 @@ static void call_ng_main_flags(sdp_ng_flags *out, str *key, bencode_item_t *valu
 		case CSH_LOOKUP("recording file"):
 			out->recording_file = s;
 			break;
+		case CSH_LOOKUP("recording-media-slot-offer"):
+			// This needs to be > 0
+			out->media_rec_slot_offer = bencode_get_integer_str(value, out->media_rec_slot_offer);
+			//out->media_rec_slot_offer = parser->get_int_str(value, out->media_rec_slot_offer);
+		break;
+		case CSH_LOOKUP("recording-media-slot-answer"):
+			// This needs to be > 0
+			out->media_rec_slot_answer = bencode_get_integer_str(value, out->media_rec_slot_answer);
+			//out->media_rec_slot_answer = parser->get_int_str(value, out->media_rec_slot_answer);
+		break;
+		case CSH_LOOKUP("recording-media-slots"):
+			out->media_rec_slots = parser->get_int_str(value, out->media_rec_slots);
+		break;
 		case CSH_LOOKUP("passthrough"):
 		case CSH_LOOKUP("passthru"):
 			switch (__csh_lookup(&s)) {

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -3,15 +3,14 @@
 
 #include "types.h"
 #include <libavutil/frame.h>
+#include <stdint.h>
 
-#define MIX_MAX_INPUTS 4
+#define MIX_MAX_INPUTS 8
 
 mix_t *mix_new(void);
 void mix_destroy(mix_t *mix);
 int mix_config(mix_t *, const format_t *format);
-int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, void *, output_t *output);
-unsigned int mix_get_index(mix_t *, void *);
-
-
+int mix_add(mix_t *mix, AVFrame *frame, unsigned int idx, uint32_t ssrc, output_t *output);
+unsigned int mix_get_index(mix_t *, uint32_t ssrc, unsigned int, unsigned int);
 #endif
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -184,6 +184,7 @@ struct decode_s {
 	decoder_t *dec;
 	resample_t mix_resampler;
 	unsigned int mixer_idx;
+	uint32_t last_ssrc;
 };
 
 

--- a/rtpengine.code-workspace
+++ b/rtpengine.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
As per the discussion on the  mailing list, this changes the recorder to use the SSRC as the key for the mixer input_ref

https://groups.google.com/g/rtpengine/c/mKTS0w_GWP8/m/16yoFSvbBgAJ