### PR TITLE
Add inbound-peer, outbound-peer and peer flags for automatic interface selection

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1619,6 +1619,17 @@ static void call_ng_flags_freqs(const ng_parser_t *parser, parser_arg value, sdp
 	}
 }
 
+static void call_ng_flags_peer_address(const str *peer_ip, str *direction, const char *direction_text) {
+	const str *resolved = resolve_interface_from_peer_ip(peer_ip);
+	if (resolved) {
+		*direction = *resolved;
+		ilog(LOG_DEBUG, "%s peer " STR_FORMAT " resolved to interface " STR_FORMAT,
+			direction_text, STR_FMT(peer_ip), STR_FMT(resolved));
+	}
+	else
+		ilog(LOG_WARN, "Failed to resolve %s peer address " STR_FORMAT, direction_text, STR_FMT(peer_ip));
+}
+
 static void call_ng_received_from_string(sdp_ng_flags *flags, str *s) {
 	flags->received_from_family = STR_NULL;
 	flags->received_from_address = *s;
@@ -1964,6 +1975,9 @@ void call_ng_main_flags(const ng_parser_t *parser, str *key, parser_arg value, h
 		case CSH_LOOKUP("from-interface"):
 			out->direction[0] = s;
 			break;
+		case CSH_LOOKUP("inbound-peer"):
+			call_ng_flags_peer_address(&s, &out->direction[0], "Inbound");
+			break;
 		case CSH_LOOKUP("from-label"):
 		case CSH_LOOKUP("label"):
 			out->label = s;
@@ -2046,6 +2060,9 @@ void call_ng_main_flags(const ng_parser_t *parser, str *key, parser_arg value, h
 			break;
 		case CSH_LOOKUP("interface"):
 			out->interface = s;
+			break;
+		case CSH_LOOKUP("peer"):
+			call_ng_flags_peer_address(&s, &out->interface, "Interface");
 			break;
 		case CSH_LOOKUP("instance"):
 			out->instance = s;
@@ -2311,6 +2328,9 @@ void call_ng_main_flags(const ng_parser_t *parser, str *key, parser_arg value, h
 			break;
 		case CSH_LOOKUP("to-interface"):
 			out->direction[1] = s;
+			break;
+		case CSH_LOOKUP("outbound-peer"):
+			call_ng_flags_peer_address(&s, &out->direction[1], "Outbound");
 			break;
 		case CSH_LOOKUP("to-label"):
 			out->to_label = s;

--- a/docs/ng_control_protocol.md
+++ b/docs/ng_control_protocol.md
@@ -381,6 +381,14 @@ Optionally included keys are:
     "received from" direction of this message. Identical to setting the first
     `direction=` value.
 
+* `inbound-peer`
+
+    Contains an IP address (IPv4 or IPv6) of the peer from which media will be
+    received. RTPengine performs a routing table lookup to determine which local
+    interface would be used to reach this peer, and uses that interface for the
+    inbound direction. Equivalent to setting `from-interface` with the resolved
+    interface name.
+
 * `frequency` or `frequencies`
 
     Sets the tone frequency or frequencies for `DTMF-security=tone` in Hertz.
@@ -456,6 +464,13 @@ Optionally included keys are:
 	Contains a single string naming one of the configured interfaces, just like `direction` does. The
 	`interface` option is used instead of `direction` where only one interface is required (e.g. outside
 	of an offer/answer scenario), for example in the `publish` or `subscribe request` commands.
+
+* `peer`
+
+    Contains an IP address (IPv4 or IPv6) of a peer. RTPengine performs a routing
+    table lookup to determine which local interface would be used to reach this peer,
+    and uses that interface for the call. Equivalent to setting `interface` with the
+    resolved interface name.
 
 * `label` or `from-label`
 
@@ -796,6 +811,14 @@ Optionally included keys are:
     Contains a string identifying the network interface pertaining to the
     "going to" direction of this message. Identical to setting the second
     `direction=` value.
+
+* `outbound-peer`
+
+    Contains an IP address (IPv4 or IPv6) of the peer to which media will be
+    sent. RTPengine performs a routing table lookup to determine which local
+    interface would be used to reach this peer, and uses that interface for the
+    outbound direction. Equivalent to setting `to-interface` with the resolved
+    interface name.
 
 * `to-label`
 

--- a/include/media_socket.h
+++ b/include/media_socket.h
@@ -389,6 +389,7 @@ struct local_intf *get_interface_address(const struct logical_intf *lif, sockfam
 struct local_intf *get_any_interface_address(const struct logical_intf *lif, sockfamily_t *fam);
 void interfaces_exclude_port(endpoint_t *);
 bool is_local_endpoint(const struct intf_address *addr, unsigned int port);
+const str *resolve_interface_from_peer_ip(const str *peer_ip);
 
 struct socket_port_link get_specific_port(unsigned int port,
 		struct intf_spec *spec, const str *label);


### PR DESCRIPTION
Opening this for discussion.

In loosely-coupled or heterogeneous/dynamic (cough kubernetes cough) multihomed environments is often hard to understand which interface to use. Ideally this should be doable if "in advance" is possibile to understand which rtpengine instance is going to be used, which is not easy nor handled by the protocol right now.

<strike>
I'm proposing to introduce a new direction flag format `auto-to-<ip>` that automatically selects the matching configured rtpengine interface based on the system's routing table. `<ip>` can be either IPv4 or IPv6.~~

~~When a direction flag contains `auto-to-<ip>`, the system:
- Uses a temporary UDP socket to determine the local address assigned by routing (like is done by freeswitch or janus or others)
- Finds the first configured rtpengine interface matching that local address
- Uses that interface for the media stream (effectively replacing the `auto-to-<ip>` given in the direction with the real configured interface name)
</strike>

I'm proposing to introduce a ~two~ three new NG protocol flags that automatically select the matching configured rtpengine interface based on the system's routing table:
  
    - inbound-peer=<ip>: resolves to interface for inbound (from) direction
    - outbound-peer=<ip>: resolves to interface for outbound (to) direction
    - peer=<ip>: resolves to interface when only one interface is required
   
When these flags are used, the system:
    - Uses a temporary UDP socket to determine the local address assigned by routing
    - Finds the first configured rtpengine interface matching that local address
    - Uses that interface for the media stream

This allows for dynamic interface selection based on network topology without requiring explicit interface names in the signaling.

<strike>
The change is fully backward compatible and will not add any additional processing if the interfaces keeps original names (unless they are named `auto-to-<something>`)

The usage is meant to provide the rtp destination ip address in `auto-to-<ip>` from the caller, and how is computed is out of this scope. (On answer it can be computed by peer sdp, but on offer depends on the underlying logic, so I've decided to keep this decision external).
</strike>

The change is fully backward compatible.

In our use case we have rtpengine nodes running in network mode host across a kubernetes cluster, which gets automatically configured with all available interfaces of the host, because that cluster is multihomed and may receive traffic on any side. Right now we've "solved" it by having a sidecar container within each rtpengine which does exactly the same, but this breaks the possibility to add multiple rtpengines to each kamailio node, because we don't know which node is going to be used before calling manage/offer/etc.

What do you think?