### PR TITLE
fix build error on Ubuntu focal

### DIFF
--- a/lib/netfilter_api.c
+++ b/lib/netfilter_api.c
@@ -11,6 +11,8 @@
 #include <glib.h>
 #include <assert.h>
 #include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
 
 
 struct nfapi_socket {


### PR DESCRIPTION
From https://kamailio.sipwise.com/view/rtpengine/job/rtpengine-nightly-binaries/494/consoleText

```
cc -c -g -O2 -fdebug-prefix-map=/build/rtpengine-14.1.0.0+0~mr14.1.0.0~ubuntu20.04.20251204015035.436=. -fstack-protector-strong -Wformat -Werror=format-security -DRTPENGINE_VERSION="\"14.1.0.0+0~mr14.1.0.0~ubuntu20.04.20251204015035.436\""  -DHAVE_LIBSYSTEMD  -g -O2 -fdebug-prefix-map=/build/rtpengine-14.1.0.0+0~mr14.1.0.0~ubuntu20.04.20251204015035.436=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -flto=auto -ffat-lto-objects -pthread -std=c11 -I. -I../kernel-module/ -I../lib/ -I../include/ -Iprivate -D_GNU_SOURCE -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -pthread -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include    -pthread   -DPCRE2_CODE_UNIT_WIDTH=8 -I/usr/include/x86_64-linux-gnu  -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/libmount -I/usr/include/blkid    -DWITH_IPTABLES_OPTION -DWITHOUT_CODECLIB  -DHAVE_MQTT -DRTPENGINE_VERSION="\"14.1.0.0+0~mr14.1.0.0~ubuntu20.04.20251204015035.436\""  -DHAVE_LIBSYSTEMD  -g -O2 -fdebug-prefix-map=/build/rtpengine-14.1.0.0+0~mr14.1.0.0~ubuntu20.04.20251204015035.436=. -fstack-protector-strong -Wformat -Werror=format-security -O3 -flto=auto -ffat-lto-objects -fPIE ../lib/netfilter_api.c -o netfilter_api.o
../lib/netfilter_api.c: In function 'nfapi_socket_close':
../lib/netfilter_api.c:55:3: warning: implicit declaration of function 'close'; did you mean 'pclose'? [-Wimplicit-function-declaration]
   55 |   close(s->fd);
      |   ^~~~~
      |   pclose
../lib/netfilter_api.c: In function 'nfapi_recv_iter':
../lib/netfilter_api.c:173:3: error: 'errno' undeclared (first use in this function)
  173 |   errno = 0;
      |   ^~~~~
../lib/netfilter_api.c:14:1: note: 'errno' is defined in header '<errno.h>'; did you forget to '#include <errno.h>'?
   13 | #include <stdio.h>
  +++ |+#include <errno.h>
   14 | 
../lib/netfilter_api.c:173:3: note: each undeclared identifier is reported only once for each function it appears in
  173 |   errno = 0;
      |   ^~~~~
../lib/netfilter_api.c:239:14: error: 'ERANGE' undeclared (first use in this function)
  239 |      errno = ERANGE;
      |              ^~~~~~
```
It seems that after 09be6451d5f8690c24a37cef7f20cc59e2f62707 some headers are missing.

After this change I see no error or warning:
```
cc -c -g -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes -Werror=return-type -Wshadow -pthread -std=c11 -I. -I../kernel-module/ -I../lib/ -I../include/ -Iprivate -D_GNU_SOURCE -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/│
glib-2.0/include  -pthread -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include    -pthread   -DPCRE2_CODE_UNIT_WIDTH=8 -I/usr/include/x86_64-linux-gnu  -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib│
-2.0/include -pthread -I/usr/include/libmount -I/usr/include/blkid    -DWITH_IPTABLES_OPTION -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-g│
nu   -I/usr/include/opus  -DWITH_TRANSCODING -I/usr/include/mysql     -DHAVE_MQTT -DRTPENGINE_VERSION="\"14.1.0.0+0~mr14.1.0.0 git-vseva/fix-23285cb1\""  -DHAVE_LIBSYSTEMD  -g -O2 -fdebug-prefix-map=/code=. -fstack-protector-strong -Wformat -Werror=forma│
t-security -O3 -flto=auto -ffat-lto-objects -fPIE ../lib/netfilter_api.c -o netfilter_api.o                                                                                                                                                                   │
../utils/const_str_hash "../lib/codeclib.c" -g -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes -Werror=return-type -Wshadow -pthread -std=c11 -I. -I../kernel-module/ -I../lib/ -I../include/ -Iprivate -D_GNU_SOURCE -I/usr/include│
/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include  -pthread -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include    -pthread   -DPCRE2_CODE_UNIT_WIDTH=8 -I/usr/include/x86_64-linux-gnu  -I/usr/include/json-glib-1.0 -I/usr/include/gli│
b-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/libmount -I/usr/include/blkid    -DWITH_IPTABLES_OPTION -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-li│
nux-gnu  -I/usr/include/x86_64-linux-gnu   -I/usr/include/opus  -DWITH_TRANSCODING -I/usr/include/mysql     -DHAVE_MQTT -DRTPENGINE_VERSION="\"14.1.0.0+0~mr14.1.0.0 git-vseva/fix-23285cb1\""  -DHAVE_LIBSYSTEMD  -g -O2 -fdebug-prefix-map=/code=. -fstack-p│
rotector-strong -Wformat -Werror=format-security -O3 -flto=auto -ffat-lto-objects -fPIE < "../lib/codeclib.c" > "../lib/codeclib.strhash.c"                                                                                                                   │
cc -c -g -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wstrict-prototypes -Werror=return-type -Wshadow -pthread -std=c11 -I. -I../kernel-module/ -I../lib/ -I../include/ -Iprivate -D_GNU_SOURCE -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/│
glib-2.0/include  -pthread -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include    -pthread   -DPCRE2_CODE_UNIT_WIDTH=8 -I/usr/include/x86_64-linux-gnu  -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib│
-2.0/include -pthread -I/usr/include/libmount -I/usr/include/blkid    -DWITH_IPTABLES_OPTION -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-gnu  -I/usr/include/x86_64-linux-g│
nu   -I/usr/include/opus  -DWITH_TRANSCODING -I/usr/include/mysql     -DHAVE_MQTT -DRTPENGINE_VERSION="\"14.1.0.0+0~mr14.1.0.0 git-vseva/fix-23285cb1\""  -DHAVE_LIBSYSTEMD  -g -O2 -fdebug-prefix-map=/code=. -fstack-protector-strong -Wformat -Werror=forma│
t-security -O3 -flto=auto -ffat-lto-objects -fPIE ../lib/codeclib.strhash.c -o codeclib.strhash.o
```