### PR TITLE
Fix nft_rtpengine compilation on AlmaLinux 9.x kernel 5.14

### DIFF
--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -6830,8 +6830,10 @@ static int rtpengine_expr_init(const struct nft_ctx *ctx, const struct nft_expr 
 }
 
 static int rtpengine_expr_dump(struct sk_buff *skb, const struct nft_expr *expr
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
-		, bool reset
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && \
+     defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,0))
+                , bool reset
 #endif
 )
 {


### PR DESCRIPTION
Add support for RHEL/AlmaLinux 9 kernels which backport the 'reset' parameter to nft_expr_dump function from kernel 6.2.0.

Tested on AlmaLinux 9.7 with kernel 5.14.0-611.11.1.el9_7.x86_64