### PR TITLE
fixes dkms module build

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -28,7 +28,7 @@ Conflicts:	%{name}-kernel < %{version}-%{release}
 %endif
 
 %if 0%{?rhel} >= 8
-%define mysql_devel_pkg mariadb-devel
+%define mysql_devel_pkg mariadb-connector-c-devel
 %else
 %define mysql_devel_pkg mysql-devel
 %endif


### PR DESCRIPTION
During master compilation and installation, I see an error
```
Building module(s)
# command: make -j4 KERNELRELEASE=5.14.0-596.el9.aarch64 -C /lib/modules/5.14.0-596.el9.aarch64/build M=/var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build RTPENGINE_VERSION=14.1.0.0+0~mr14.1.0.0-4.el9
make: Entering directory '/usr/src/kernels/5.14.0-596.el9.aarch64'
/var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build/gen-rtpengine-kmod-flags >/var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build/rtpengine-kmod.mk
  CC [M]  /var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build/nft_rtpengine.o
/var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build/nft_rtpengine.c:6115:10: fatal error: extmap_filter.inc.c: No such file or directory
 6115 | #include "extmap_filter.inc.c"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [scripts/Makefile.build:249: /var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build/nft_rtpengine.o] Error 1
make: *** [Makefile:1951: /var/lib/dkms/ngcp-rtpengine/14.1.0.0+0~mr14.1.0.0-4.el9/build] Error 2
make: Leaving directory '/usr/src/kernels/5.14.0-596.el9.aarch64'

# exit code: 2
# elapsed time: 00:00:01
```

This happens because `extmap_filter.inc.c` in the module sources is not packaged.
First commit fixed this.

Second commit fix correct MariaDB dependency for the module build.