### PR TITLE
Add linker flag to fix LTO for some toolchains

### DIFF
--- a/utils/gen-common-flags
+++ b/utils/gen-common-flags
@@ -63,7 +63,7 @@ if command -v dpkg-buildflags >/dev/null; then
   LDFLAGS_DEFAULT=$(dpkg-buildflags --get LDFLAGS)
 fi
 CFLAGS_DEFAULT+=" -O3 -flto=auto -ffat-lto-objects"
-LDFLAGS_DEFAULT+=" -flto=auto"
+LDFLAGS_DEFAULT+=" -flto=auto -fuse-linker-plugin"
 
 echo "export CFLAGS_DEFAULT := ${CFLAGS_DEFAULT}"
 echo "export CPPFLAGS_DEFAULT := ${CPPFLAGS_DEFAULT}"


### PR DESCRIPTION
When building on EL with the default flags (LTO), the build fails during the final link stage with many undefined symbol errors. Explicitly enabling the linker plugin ensures the toolchain processes LTO IR during linking.

This should not affect Debian or other toolchains that implicitly enable the plugin, where the flag is redundant and has no effect.

Tested builds:
- AlmaLinux 10: GCC 14.3.1 (quirk: disable `iptc` here, no legacy iptables)
- AlmaLinux 9: GCC 11.5.0
- AlmaLinux 9/10 + gcc-toolset-15: GCC 15.1.1 (quirk: don't need `-latomic` here)