### PR TITLE
mr13.5.1: Fix up iptables and mysqlclient with EL packaging changes

### DIFF
--- a/daemon/.ycm_extra_conf.py
+++ b/daemon/.ycm_extra_conf.py
@@ -43,7 +43,7 @@ flags = [
     '-DPCRE2_CODE_UNIT_WIDTH=8',
     '-DRTPENGINE_VERSION="dummy"',
     '-DRE_PLUGIN_DIR="/usr/lib/rtpengine"',
-    '-DWITH_IPTABLES_OPTION',
+    '-DHAVE_LIBIPTC',
     '-DWITH_TRANSCODING',
     '-DHAVE_BCG729',
     '-DHAVE_MQTT',

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,7 +4,6 @@ export top_srcdir = ..
 
 include ../lib/deps.Makefile
 
-with_iptables_option ?= yes
 with_transcoding ?= yes
 
 ifeq ($(origin CFLAGS),undefined)
@@ -29,10 +28,7 @@ CFLAGS+=	$(CFLAGS_JSON_GLIB)
 CFLAGS+=	$(CFLAGS_LIBWEBSOCKETS)
 CFLAGS+=	$(CFLAGS_LIBNFTNL)
 CFLAGS+=	$(CFLAGS_LIBMNL)
-ifeq ($(with_iptables_option),yes)
 CFLAGS+=	$(CFLAGS_LIBIPTC)
-CFLAGS+=	-DWITH_IPTABLES_OPTION
-endif
 ifeq ($(with_transcoding),yes)
 CFLAGS+=	$(CFLAGS_LIBAVCODEC)
 CFLAGS+=	$(CFLAGS_LIBAVFORMAT)

--- a/daemon/iptables.c
+++ b/daemon/iptables.c
@@ -5,7 +5,7 @@
 int (*iptables_add_rule)(const socket_t *local_sock, const str *comment);
 int (*iptables_del_rule)(const socket_t *local_sock);
 
-#ifdef WITH_IPTABLES_OPTION
+#ifdef HAVE_IPTABLES
 
 #include <stdio.h>
 #include <errno.h>
@@ -308,7 +308,7 @@ static int __iptables_del_rule(const socket_t *local_sock) {
 	return 0;
 }
 
-#endif // WITH_IPTABLES_OPTION
+#endif // HAVE_IPTABLES
 
 static int __iptables_stub(void) {
 	return 0;
@@ -325,7 +325,7 @@ void iptables_init(void) {
 		return;
 	}
 
-#ifdef WITH_IPTABLES_OPTION
+#ifdef HAVE_IPTABLES
 
 	iptables_add_rule = __iptables_add_rule;
 	iptables_del_rule = __iptables_del_rule;
@@ -375,6 +375,6 @@ out:
 	if (err)
 		ilog(LOG_ERROR, "Failed to flush iptables chain: %s (%s)", err, strerror(errno));
 
-#endif // WITH_IPTABLES_OPTION
+#endif // HAVE_IPTABLES
 
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -779,7 +779,7 @@ static void options(int *argc, char ***argv, charp_ht templates) {
 		{ "recording-method",0, 0, G_OPTION_ARG_STRING,	&rtpe_config.rec_method,	"Strategy for call recording",		"pcap|proc|all"	},
 		{ "recording-format",0, 0, G_OPTION_ARG_STRING,	&rtpe_config.rec_format,	"File format for stored pcap files",	"raw|eth"	},
 		{ "record-egress",0, 0, G_OPTION_ARG_NONE,	&rtpe_config.rec_egress,	"Recording egress media instead of ingress",	NULL	},
-#ifdef WITH_IPTABLES_OPTION
+#ifdef HAVE_IPTABLES
 		{ "iptables-chain",0,0,	G_OPTION_ARG_STRING,	&rtpe_config.iptables_chain,"Add explicit firewall rules to this iptables chain","STRING" },
 #endif
 		{ "codecs",	0, 0,	G_OPTION_ARG_NONE,	&codecs,		"Print a list of supported codecs and exit",	NULL },

--- a/utils/gen-common-flags
+++ b/utils/gen-common-flags
@@ -79,7 +79,6 @@ gen-pkgconf-flags LIBAVUTIL           libavutil
 gen-pkgconf-flags LIBCURL             libcurl
 gen-pkgconf-flags LIBCRYPTO           libcrypto
 gen-pkgconf-flags LIBEVENT            libevent_pthreads
-gen-pkgconf-flags LIBIPTC             libiptc
 gen-pkgconf-flags LIBMNL              libmnl
 gen-pkgconf-flags LIBNFTNL            libnftnl
 gen-pkgconf-flags LIBPCRE             libpcre2-8
@@ -92,7 +91,6 @@ gen-pkgconf-flags OPENSSL             openssl
 gen-pkgconf-flags OPUS                opus
 gen-pkgconf-flags SPANDSP             spandsp
 gen-pkgconf-flags LIBJWT              libjwt
-gen-pkgconf-flags MYSQL               mysqlclient
 gen-pkgconf-flags LIBHIREDIS          hiredis
 gen-pkgconf-flags LIBPCAP             libpcap
 
@@ -107,8 +105,22 @@ if pkg-config --exists libsystemd; then
   echo "CFLAGS_LIBSYSTEMD += -DHAVE_LIBSYSTEMD"
 fi
 
+
 # look for liburing
 if pkg-config --atleast-version=2.3 liburing; then
   gen-pkgconf-flags LIBURING liburing
   echo "CFLAGS_LIBURING += -DHAVE_LIBURING"
+fi
+
+# look for libiptc
+if pkg-config libiptc; then
+  gen-pkgconf-flags LIBIPTC libiptc
+  echo "CFLAGS_LIBIPTC += -DHAVE_LIBIPTC"
+fi
+
+# alternative MySQL/MariaDB
+if pkg-config --exists libmariadb; then
+  gen-pkgconf-flags MYSQL libmariadb
+else
+  gen-pkgconf-flags MYSQL mysqlclient
 fi


### PR DESCRIPTION
Might be too intrusive for LTS but here goes:

This will fix-up RPM packaging (mysqlclient -> libmariadb, no libiptc on RHEL 10) - I copied the changes from master (cc53062ca1).

The default `el/rtpengine.spec` now packages cleanly on AlmaLinux 8-10.

If this breaks Debian I'll submit another attempt using `with_iptables_option=no` on EL10