### PR TITLE
Increase input buffer size for getaddrinfo to 256

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -695,7 +695,7 @@ bool sockaddr_getaddrinfo_alt(sockaddr_t *a, sockaddr_t *a2, const char *s) {
 bool endpoint_parse_any_getaddrinfo_alt(endpoint_t *d, endpoint_t *d2, const char *s) {
 	unsigned int len;
 	const char *ep;
-	char buf[64];
+	char buf[256];
 
 	ep = strrchr(s, ':');
 	if (!ep) {


### PR DESCRIPTION
Previously, rtpengine would refuse to resolve any hostnames longer than 64 characters. For example: the hostname of the Redis server to connect to.