### PR TITLE
Add no-tls-id flag to disable a=tls-id SDP attribute generation

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2206,8 +2206,13 @@ static void __dtls_logic(const sdp_ng_flags *flags,
 		__dtls_restart(other_media);
 	}
 	else if (ice_is_restart(other_media->ice_agent, sp) && !other_media->tls_id.len && !sp->tls_id.len) {
-		ilogs(crypto, LOG_INFO, "ICE restart without TLS-ID, restarting DTLS");
-		__dtls_restart(other_media);
+		// Skip DTLS restart if no-tls-id flag is active (user opted out of TLS-ID handling)
+		if (!flags->no_tls_id) {
+			ilogs(crypto, LOG_INFO, "ICE restart without TLS-ID, restarting DTLS");
+			__dtls_restart(other_media);
+		} else {
+			ilogs(crypto, LOG_INFO, "ICE restart without TLS-ID detected, but no-tls-id flag is active - skipping DTLS restart");
+		}
 	}
 
 	other_media->tls_id = call_str_cpy(&sp->tls_id);

--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -1255,6 +1255,10 @@ void call_ng_flags_flags(str *s, unsigned int idx, helper_arg arg) {
 		case CSH_LOOKUP("no RTCP attribute"):
 			out->no_rtcp_attr = true;
 			break;
+		case CSH_LOOKUP("no-tls-id"):
+		case CSH_LOOKUP("no tls id"):
+			out->no_tls_id = true;
+			break;
 		case CSH_LOOKUP("no-jitter-buffer"):
 		case CSH_LOOKUP("no jitter buffer"):
 			out->disable_jb = true;

--- a/daemon/sdp.c
+++ b/daemon/sdp.c
@@ -2594,7 +2594,7 @@ static void insert_dtls(GString *s, struct call_media *media, struct dtls_connec
 
 	insert_fingerprint(s, media, flags, hf, fp);
 
-	if (dtls)
+	if (dtls && !flags->no_tls_id)
 		insert_tls_id(s, media, flags, dtls);
 }
 

--- a/docs/ng_control_protocol.md
+++ b/docs/ng_control_protocol.md
@@ -1161,6 +1161,13 @@ Spaces in each string may be replaced by hyphens.
 
 	Omit the `a=rtcp` line from the outgoing SDP.
 
+* `no-tls-id` or `no tls id`
+
+	Disables generation of the `a=tls-id` SDP attribute in outgoing SDP and prevents
+	automatic DTLS restart when an ICE restart occurs without a TLS-ID present. This flag
+	is useful in scenarios where TLS-ID handling should be completely bypassed, such as when
+	interoperating with endpoints that don't support or expect the `a=tls-id` attribute.
+
 * `original sendrecv`
 
 	With this flag present, *rtpengine* will leave the media direction attributes

--- a/include/call_interfaces.h
+++ b/include/call_interfaces.h
@@ -219,6 +219,7 @@ RTPE_NG_FLAGS_STR_CASE_HT_PARAMS
 		     rtcp_mirror:1,
 		     trickle_ice:1,
 	             no_rtcp_attr:1,
+	             no_tls_id:1,
 	             full_rtcp_attr:1,
 	             generate_rtcp:1,
 	             generate_rtcp_off:1,


### PR DESCRIPTION
This flag disables generation of the `a=tls-id` SDP attribute in outgoing SDP and prevents automatic DTLS restart when an ICE restart occurs without a tls-id present.
Useful for interoperating with endpoints that don't support or expect the `a=tls-id` attribute.
Hexagram_vall, thank you for your help and testing of this PR.