### PR TITLE
streambuf: check pointer isn't NULL before trying to free it

### DIFF
--- a/lib/streambuf.c
+++ b/lib/streambuf.c
@@ -53,6 +53,8 @@ struct streambuf *streambuf_new(struct poller *p, int fd) {
 
 
 void streambuf_destroy(struct streambuf *b) {
+	if(!b)
+		return;
 	g_string_free(b->buf, TRUE);
 	g_free(b);
 }


### PR DESCRIPTION
we've had a few segfaults recently in `rtpengine-recording` because of this. I'm not yet sure on the exact reason for it being in this state but at least handling the NULL pointer should ensure it doesn't crash