### PR TITLE
Add modprobe params for nft_rtpengine module when using EL/systemd

### DIFF
--- a/el/rtpengine.spec
+++ b/el/rtpengine.spec
@@ -258,6 +258,19 @@ fi
   dkms build -m %{name} -v %{version}-%{release} --rpm_safe_upgrade &&
   dkms install -m %{name} -v %{version}-%{release} --rpm_safe_upgrade --force
 %endif
+
+if ! [ -f /etc/modprobe.d/rtpengine.conf ] || grep -q RPM-GENERATED /etc/modprobe.d/rtpengine.conf; then
+        OPTIONS="options nft_rtpengine proc_mask=0x7"
+
+        PUID=$(id -u %{name} 2> /dev/null)
+        test -z "$PUID" || OPTIONS="$OPTIONS proc_uid=$PUID"
+        PGID=$(id -g %{name} 2> /dev/null)
+        test -z "$PGID" || OPTIONS="$OPTIONS proc_gid=$PGID"
+
+        ( echo "# RPM-GENERATED FILE";
+          echo "$OPTIONS" ) > /etc/modprobe.d/rtpengine.conf
+fi
+
 true
 
 


### PR DESCRIPTION
Spent quite some time debugging this message, after building and installing using the bundled spec file:

`ERR: [core] FAILED TO DELETE KERNEL TABLE 0 (Permission denied), KERNEL FORWARDING DISABLED`

Seems like options for the module is not handled at all for el-based systems using systemd, causing issues when running as non-root.

Trying now to add similar functionality found in https://github.com/sipwise/rtpengine/blob/master/debian/ngcp-rtpengine-daemon.postinst for Debian based systems.