### PR TITLE
kernel-module: detect nft_expr_ops.validate signature from headers

### DIFF
--- a/kernel-module/Makefile
+++ b/kernel-module/Makefile
@@ -1,4 +1,4 @@
-KSRC   ?= /lib/modules/$(shell uname -r)/build
+KSRC   ?= /lib/modules/$(or $(KERNELRELEASE),$(shell uname -r))/build
 KBUILD := $(KSRC)
 M      ?= $(CURDIR)
 

--- a/kernel-module/gen-rtpengine-kmod-flags
+++ b/kernel-module/gen-rtpengine-kmod-flags
@@ -31,3 +31,39 @@ if [ -z "${RTPENGINE_VERSION}" ]; then
   fi
   echo "RTPENGINE_VERSION := ${RTPENGINE_VERSION}"
 fi
+
+# Compile test: detect nft_expr_ops.validate callback signature.
+# Distribution kernels (e.g. Ubuntu) may backport the 2-param validate
+# callback (mainline commit eaf9b2c875ec, merged in 6.12) to earlier
+# kernel versions without changing LINUX_VERSION_CODE. A compile test
+# is the only reliable way to detect the actual API.
+#
+# The test tries to assign a 3-param function to .validate. If it
+# compiles, the old API is present and we set the flag. If it fails
+# (incompatible pointer types), the kernel has the new 2-param version.
+
+# KERNELRELEASE is set by kbuild to the target kernel version, which
+# may differ from the running kernel during DKMS cross-kernel builds.
+KSRC="${KSRC:-/lib/modules/${KERNELRELEASE:-$(uname -r)}/build}"
+
+if [ -d "${KSRC}" ]; then
+  nft_test_dir=$(mktemp -d)
+  cat > "${nft_test_dir}/nft_test.c" <<'TESTEOF'
+#include <linux/module.h>
+#include <net/netfilter/nf_tables.h>
+static int test_validate(const struct nft_ctx *ctx, const struct nft_expr *expr,
+    const struct nft_data **data) { return 0; }
+static struct nft_expr_ops __attribute__((unused)) test_ops = {
+    .validate = test_validate };
+MODULE_LICENSE("GPL");
+TESTEOF
+  echo "obj-m := nft_test.o" > "${nft_test_dir}/Makefile"
+
+  # Use env -i to prevent kbuild state (KBUILD_EXTMOD, M, MAKEFLAGS, etc.)
+  # leaking from an outer kbuild invocation into the compile test.
+  if env -i PATH="$PATH" make -j1 -C "${KSRC}" M="${nft_test_dir}" modules >/dev/null 2>&1; then
+    echo "ccflags-y += -DNFT_EXPR_OPS_VALIDATE_HAS_DATA"
+  fi
+
+  rm -rf "${nft_test_dir}"
+fi

--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -6844,7 +6844,7 @@ static int rtpengine_expr_dump(struct sk_buff *skb, const struct nft_expr *expr
 }
 
 static int rtpengine_expr_validate(const struct nft_ctx *ctx, const struct nft_expr *expr
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)
+#if defined(NFT_EXPR_OPS_VALIDATE_HAS_DATA)
 		, const struct nft_data **data
 #endif
 )


### PR DESCRIPTION
## Summary

The current `LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0)` check for the `nft_expr_ops.validate` callback signature breaks on distribution kernels that backport the API change without updating `LINUX_VERSION_CODE`.

**Upstream commit:** [`eaf9b2c875ec`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=eaf9b2c875ece22768b78aa38da8b232e5de021b) — "netfilter: nf_tables: drop unused 3rd argument from validate callback ops" (Florian Westphal, 2024-09-03)

**Affected:** Ubuntu 24.04 kernel `6.8.0-106` (stable patchset 2026-01-27, LP: #2139158) backports this commit to a 6.8 kernel, causing the DKMS build to fail:

```
error: initialization of 'int (*)(const struct nft_ctx *, const struct nft_expr *)'
from incompatible pointer type 'int (*)(const struct nft_ctx *, const struct nft_expr *,
const struct nft_data **)' [-Werror=incompatible-pointer-types]
```

## Fix

Replace the `LINUX_VERSION_CODE` check with compile-time header detection:

1. **Makefile**: Inspect the installed kernel headers for the actual `validate` callback signature. If `nft_data` appears in the validate parameter list, define `NFT_EXPR_OPS_VALIDATE_HAS_DATA`.
2. **nft_rtpengine.c**: Use `#if defined(NFT_EXPR_OPS_VALIDATE_HAS_DATA)` instead of the version check.

This correctly handles:
- Mainline kernels < 6.12 (3-param) ✅
- Mainline kernels >= 6.12 (2-param) ✅
- Distribution kernels with backported API changes (e.g. Ubuntu 6.8.0-106) ✅

## Testing

Compiled and verified against:
- Ubuntu 24.04 `6.8.0-90-generic` (old 3-param API) — builds successfully
- Ubuntu 24.04 `6.8.0-106-generic` (backported 2-param API) — builds successfully
- DKMS install on Ubuntu 24.04 with kernel `6.8.0-106` — module loads correctly