### PR TITLE
Cilium fix

### DIFF
--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -5017,6 +5017,13 @@ static int send_proxy_packet4(struct sk_buff *skb, const struct re_address *src,
 	}
 
 	ip_select_ident(net, skb, NULL);
+	/* Zero queue_mapping: the skb is a copy of the received packet and
+	 * inherits the NIC RX queue index.  On Cilium/GKE DPv2 nodes the
+	 * egress TC BPF program (cil_to_netdev) uses queue_mapping as an EDT
+	 * bandwidth-throttle aggregate key; a non-zero value enters the
+	 * throttle code path which can tail-call into TC_ACT_SHOT when the
+	 * aggregate slot is uninitialised. */
+	skb->queue_mapping = 0;
 	ip_local_out(net, skb->sk, skb);
 
 	return 0;
@@ -5107,6 +5114,9 @@ static int send_proxy_packet6(struct sk_buff *skb, const struct re_address *src,
 		skb->ip_summed = CHECKSUM_COMPLETE;
 	}
 
+	/* Same reasoning as send_proxy_packet4: zero queue_mapping before
+	 * handing the packet to the egress TC BPF program. */
+	skb->queue_mapping = 0;
 	ip6_local_out(net, skb->sk, skb);
 
 	return 0;

--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -4979,6 +4979,12 @@ static int send_proxy_packet4(struct sk_buff *skb, const struct re_address *src,
 	};
 
 	skb->protocol = htons(ETH_P_IP);
+	/* Clear any mark inherited from the received packet.  On Cilium/GKE
+	 * DPv2 nodes, ingress BPF stamps identity/decrypt marks on incoming
+	 * skbs; leaving them in place can match an ip rule (e.g.
+	 * "fwmark 0x200/0xf00 → table 2004") and send forwarded packets into
+	 * a Cilium-internal routing table that has no default gateway. */
+	skb->mark = 0;
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0)) || \
 		(defined(RHEL_RELEASE_CODE) && LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0) && \
@@ -5066,6 +5072,9 @@ static int send_proxy_packet6(struct sk_buff *skb, const struct re_address *src,
 	memcpy(&ih->daddr, dst->u.ipv6, sizeof(ih->daddr));
 
 	skb->protocol = htons(ETH_P_IPV6);
+	/* Same reasoning as send_proxy_packet4: clear inherited Cilium ingress
+	 * marks to avoid misrouting via Cilium-internal tables. */
+	skb->mark = 0;
 
 	memset(&fl6, 0, sizeof(fl6));
 	memcpy(&fl6.saddr, src->u.ipv6, sizeof(fl6.saddr));

--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -5024,6 +5024,14 @@ static int send_proxy_packet4(struct sk_buff *skb, const struct re_address *src,
 	 * throttle code path which can tail-call into TC_ACT_SHOT when the
 	 * aggregate slot is uninitialised. */
 	skb->queue_mapping = 0;
+	/* Zero skb->tstamp: skb_copy_expand() preserves the receive timestamp
+	 * (a REALTIME ktime ~1.77e18 ns, i.e. Unix epoch).  The fq qdisc
+	 * compares skb->tstamp against the monotonic clock (seconds since boot)
+	 * without checking tstamp_type; a REALTIME timestamp is billions of
+	 * nanoseconds ahead of monotonic_now and exceeds the 2-second horizon,
+	 * causing fq_packet_beyond_horizon() to silently drop every packet.
+	 * Clearing tstamp tells fq to transmit immediately. */
+	skb->tstamp = 0;
 	ip_local_out(net, skb->sk, skb);
 
 	return 0;
@@ -5114,9 +5122,10 @@ static int send_proxy_packet6(struct sk_buff *skb, const struct re_address *src,
 		skb->ip_summed = CHECKSUM_COMPLETE;
 	}
 
-	/* Same reasoning as send_proxy_packet4: zero queue_mapping before
-	 * handing the packet to the egress TC BPF program. */
+	/* Same reasoning as send_proxy_packet4: clear the inherited REALTIME
+	 * receive timestamp to prevent fq horizon drops. */
 	skb->queue_mapping = 0;
+	skb->tstamp = 0;
 	ip6_local_out(net, skb->sk, skb);
 
 	return 0;


### PR DESCRIPTION
We have been successfully running rtpengine with the kernel module for a long time on GCP Kubernetes (GKE) clusters using Dataplane V1 (kube-proxy/iptables). We recently began testing GKE Dataplane V2 (Cilium/anetd) and discovered that when rtpengine kernelizes a stream on a node running Dataplane V2, forwarded RTP packets are silently dropped. The root cause is that skb_copy_expand() — used to build the outgoing skb from the received one — copies all skb fields, three of which become harmful on the egress path in a Cilium environment.

- **skb->mark:** Cilium's ingress TC BPF program (cil_from_netdev) stamps a policy mark on every received packet (e.g. 0x200, MARK_MAGIC_DECRYPT). The node carries an ip rule fwmark 0x200/0xf00 → table 2004 (Cilium's internal routing table, no default gateway). If the mark is not cleared before the route lookup, forwarded packets are routed into that table and dropped.
- **skb->queue_mapping:** Cilium's egress TC BPF program (cil_to_netdev) uses skb->queue_mapping as the key for EDT bandwidth throttling. The NIC driver sets this field to the RX queue index; a non-zero value causes cil_to_netdev to enter the throttle path, where an uninitialised tail-call slot results in TC_ACT_SHOT.
- **skb->tstamp:** The NIC driver records a CLOCK_REALTIME receive timestamp (~1.775×10¹⁸ ns, i.e. Unix epoch) in skb->tstamp. Cilium's bandwidth manager installs an fq qdisc with a 2-second EDT horizon on host-facing interfaces. fq_packet_beyond_horizon() compares skb->tstamp against ktime_get() (CLOCK_MONOTONIC, seconds since boot) without checking tstamp_type; the REALTIME timestamp always exceeds the horizon, causing every forwarded packet to be dropped.

All three fields are zeroed in send_proxy_packet4() and send_proxy_packet6() before packet injection. The changes are no-ops in non-Cilium environments: without Cilium there are no matching fwmark rules, no cil_to_netdev BPF program, and no fq qdisc with EDT horizon on the egress interface.