### PR TITLE
Fix deb build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends:
  libavutil-dev (>= 6:10),
  libbcg729-dev <!pkg.ngcp-rtpengine.nobcg729>,
  libbencode-perl,
+ libcjson-dev,
  libcrypt-openssl-rsa-perl,
  libcrypt-rijndael-perl,
  libcurl4-openssl-dev | libcurl4-gnutls-dev,


### PR DESCRIPTION
```
/usr/include/mosquitto/libcommon_cjson.h:31:10: fatal error: cjson/cJSON.h: No such file or directory
   31 | #include <cjson/cJSON.h>
      |          ^~~~~~~~~~~~~~~
```