### PR TITLE
add(Dockerfile): libip4tc2 to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update \
   libevent-pthreads-2.1-7 \
   libglib2.0-0 \
   libhiredis1.1.0 \
+  libip4tc2 \
   libip6tc2 \
   libjson-glib-1.0-0 \
   libjwt2 \


### PR DESCRIPTION
Running the Docker image raises the following exception:

```
rtpengine: error while loading shared libraries: libip4tc.so.2: cannot open shared object file: No such file or directory
```

Adds libip4tc for ipv4 handling