### PR TITLE
support 'all' codec accept mode

### DIFF
--- a/daemon/codec.c
+++ b/daemon/codec.c
@@ -6049,6 +6049,7 @@ int codec_store_accept_one(struct codec_store *cs, const str_q *accept, bool acc
 	// local codec-accept routine: accept first supported codec, or first from "accept" list
 	// if given
 
+	bool accept_all = false;
 	rtp_payload_type *accept_pt = NULL;
 
 	for (auto_iter(l, accept->head); l; l = l->next) {
@@ -6056,6 +6057,10 @@ int codec_store_accept_one(struct codec_store *cs, const str_q *accept, bool acc
 		str *codec = l->data;
 		if (!str_cmp(codec, "any")) {
 			accept_any = true;
+			continue;
+		}
+		if (!str_cmp(codec, "all")) {
+			accept_all = true;
 			continue;
 		}
 		GQueue *pts = t_hash_table_lookup(cs->codec_names, codec);
@@ -6075,6 +6080,9 @@ int codec_store_accept_one(struct codec_store *cs, const str_q *accept, bool acc
 		if (accept_pt)
 			break;
 	}
+
+	if (accept_all && accept_any)
+		return 0;
 
 	if (!accept_pt) {
 		// none found yet - pick the first one
@@ -6105,7 +6113,15 @@ int codec_store_accept_one(struct codec_store *cs, const str_q *accept, bool acc
 			continue;
 		}
 		ensure_codec_def(pt, cs->media);
-		if (pt->codec_def && pt->codec_def->supplemental
+		if (accept_all) {
+			if (codec_def_supported(pt->codec_def)
+					|| (pt->codec_def && pt->codec_def->supplemental))
+			{
+				link = link->next;
+				continue;
+			}
+		}
+		else if (pt->codec_def && pt->codec_def->supplemental
 				&& pt->clock_rate == accept_pt->clock_rate)
 		{
 			link = link->next;

--- a/docs/ng_control_protocol.md
+++ b/docs/ng_control_protocol.md
@@ -2605,7 +2605,10 @@ the first codec that is supported for transcoding is selected. If no such codec
 is present, then the offer is rejected. The special string `any` can be given
 in the `accept` list to influence this behaviour: If `any` is listed, then the
 first codec from the offer is accepted even if it's not supported for
-transcoding.
+transcoding. The special string `all` can be given in the `accept` list to
+keep all codecs that are supported for transcoding (and their supplemental
+codecs), removing only unsupported codecs. If both `all` and `any` are given,
+all codecs from the offer are kept without removing any.
 
 ## `subscribe request` Message
 

--- a/t/auto-daemon-tests-pubsub.pl
+++ b/t/auto-daemon-tests-pubsub.pl
@@ -4848,5 +4848,144 @@ SDP
 snd($sock_a, $port_a, rtp(8, 2000, 4000, 0x3456, "\x00" x 160));
 rcv($sock_b, $port_b, rtpm(8, 2000, 4000, 0x3456, "\x00" x 160));
 
+
+
+# publish with accept all: keep all codecs including unsupported ones
+
+($sock_a, $sock_b) =
+	new_call([qw(198.51.100.14 6168)], [qw(198.51.100.14 6170)]);
+
+($port_a) = publish('publish accept all',
+	{ codec => { accept => ['all', 'any'] } }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio 6168 RTP/AVP 8 0 101
+c=IN IP4 198.51.100.14
+a=sendonly
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+----------------------------------
+v=0
+o=- SDP_VERSION IN IP4 203.0.113.1
+s=RTPE_VERSION
+t=0 0
+m=audio PORT RTP/AVP 8 0 101
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=recvonly
+a=rtcp:PORT
+SDP
+
+snd($sock_a, $port_a, rtp(8, 2000, 4000, 0x3456, "\x00" x 160));
+
+($ftr, $ttr, undef, undef, undef, $port_b) = subscribe_request('publish accept all',
+	{ 'from-tag' => ft() }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 8 0 101
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendonly
+a=rtcp:PORT
+SDP
+
+is $ftr, ft(), 'from-tag matches';
+
+subscribe_answer('publish accept all',
+	{ 'to-tag' => $ttr }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio 6170 RTP/AVP 8 0 101
+c=IN IP4 198.51.100.14
+a=recvonly
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+SDP
+
+snd($sock_a, $port_a, rtp(8, 2001, 4160, 0x3456, "\x00" x 160));
+rcv($sock_b, $port_b, rtpm(8, 2001, 4160, 0x3456, "\x00" x 160));
+
+
+
+# publish with accept all-supported: keep only supported codecs and supplementals
+
+($sock_a, $sock_b) =
+	new_call([qw(198.51.100.14 6172)], [qw(198.51.100.14 6174)]);
+
+($port_a) = publish('publish accept all-supported',
+	{ codec => { accept => ['all'] } }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio 6172 RTP/AVP 8 0 96 101
+c=IN IP4 198.51.100.14
+a=sendonly
+a=rtpmap:96 unsupported-codec/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+----------------------------------
+v=0
+o=- SDP_VERSION IN IP4 203.0.113.1
+s=RTPE_VERSION
+t=0 0
+m=audio PORT RTP/AVP 8 0 101
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=recvonly
+a=rtcp:PORT
+SDP
+
+snd($sock_a, $port_a, rtp(8, 2000, 4000, 0x3456, "\x00" x 160));
+
+($ftr, $ttr, undef, undef, undef, $port_b) = subscribe_request('publish accept all-supported',
+	{ 'from-tag' => ft() }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 8 0 101
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+a=sendonly
+a=rtcp:PORT
+SDP
+
+is $ftr, ft(), 'from-tag matches';
+
+subscribe_answer('publish accept all-supported',
+	{ 'to-tag' => $ttr }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio 6174 RTP/AVP 8 0 101
+c=IN IP4 198.51.100.14
+a=recvonly
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-15
+SDP
+
+snd($sock_a, $port_a, rtp(8, 2001, 4160, 0x3456, "\x00" x 160));
+rcv($sock_b, $port_b, rtpm(8, 2001, 4160, 0x3456, "\x00" x 160));
+
 done_testing();
 #done_testing;NGCP::Rtpengine::AutoTest::terminate('f00');exit;


### PR DESCRIPTION
Add the 'all' keyword for the codec accept option in publish mode:
- 'all': keep all codecs supported for transcoding and their
  supplemental codecs, removing only unsupported ones
- 'all' + 'any': keep all codecs from the offer without removing any