### PR TITLE
ignore rtcp-based packet loss in individual ssrc streams

### DIFF
--- a/daemon/mqtt.c
+++ b/daemon/mqtt.c
@@ -240,22 +240,24 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 	json_builder_begin_object(json);
 
 	// copy out values
-	int64_t packets, octets, packets_lost, duplicates;
+	int64_t packets, octets, packets_lost, packets_lost_rtcp, duplicates;
 	packets = atomic64_get_na(&ssrc->stats->packets);
 	octets = atomic64_get_na(&ssrc->stats->bytes);
 	packets_lost = ssrc->packets_lost;
+	packets_lost_rtcp = ssrc->packets_lost_rtcp;
 	duplicates = ssrc->duplicates;
 
 	// process per-second stats
 	int64_t cur_ts = rtpe_now;
 	int64_t last_sample;
-	int64_t sample_packets, sample_octets, sample_packets_lost, sample_duplicates;
+	int64_t sample_packets, sample_octets, sample_packets_lost, sample_packets_lost_rtcp, sample_duplicates;
 
 	// sample values
 	last_sample = atomic64_get_set(&ssrc->last_sample, cur_ts);
 	sample_packets = atomic64_get_set(&ssrc->sample_packets, packets);
 	sample_octets = atomic64_get_set(&ssrc->sample_octets, octets);
 	sample_packets_lost = atomic64_get_set(&ssrc->sample_packets_lost, packets_lost);
+	sample_packets_lost_rtcp = atomic64_get_set(&ssrc->sample_packets_lost_rtcp, packets_lost_rtcp);
 	sample_duplicates = atomic64_get_set(&ssrc->sample_duplicates, duplicates);
 
 	json_builder_set_member_name(json, "packets");
@@ -266,6 +268,9 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 
 	json_builder_set_member_name(json, "lost");
 	json_builder_add_int_value(json, packets_lost);
+
+	json_builder_set_member_name(json, "lost_rtcp");
+	json_builder_add_int_value(json, packets_lost_rtcp);
 
 	json_builder_set_member_name(json, "duplicates");
 	json_builder_add_int_value(json, duplicates);
@@ -279,6 +284,7 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 		packets -= sample_packets;
 		octets -= sample_octets;
 		packets_lost -= sample_packets_lost;
+		packets_lost_rtcp -= sample_packets_lost_rtcp;
 		duplicates -= sample_duplicates;
 
 		json_builder_set_member_name(json, "packets_per_second");
@@ -289,6 +295,9 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 
 		json_builder_set_member_name(json, "lost_per_second");
 		json_builder_add_double_value(json, (double) packets_lost * 1000000.0 / usecs_diff);
+
+		json_builder_set_member_name(json, "lost_rtcp_per_second");
+		json_builder_add_double_value(json, (double) packets_lost_rtcp * 1000000.0 / usecs_diff);
 
 		json_builder_set_member_name(json, "duplicates_per_second");
 		json_builder_add_double_value(json, (double) duplicates * 1000000.0 / usecs_diff);

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -489,7 +489,8 @@ void ssrc_receiver_report(struct call_media *m, stream_fd *sfd, const struct ssr
 	mos_calc = mos_calc_legacy;
 #endif
 
-	other_e->packets_lost = rr->packets_lost;
+	//ignore rtcp based packets lost
+	//other_e->packets_lost = rr->packets_lost;
 	mos_calc(ssb);
 	if (ssb->mos) {
 		ilog(LOG_DEBUG, "Calculated MOS from RR for %s%x%s is %.1f", FMT_M(rr->from),

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -489,8 +489,7 @@ void ssrc_receiver_report(struct call_media *m, stream_fd *sfd, const struct ssr
 	mos_calc = mos_calc_legacy;
 #endif
 
-	//ignore rtcp based packets lost
-	//other_e->packets_lost = rr->packets_lost;
+	other_e->packets_lost_rtcp = rr->packets_lost;
 	mos_calc(ssb);
 	if (ssb->mos) {
 		ilog(LOG_DEBUG, "Calculated MOS from RR for %s%x%s is %.1f", FMT_M(rr->from),

--- a/include/ssrc.h
+++ b/include/ssrc.h
@@ -75,7 +75,8 @@ struct ssrc_entry_call {
 	atomic64 last_sample,
 		 sample_packets,
 		 sample_octets,
-		 sample_packets_lost,
+		 sample_packets_lost, // local (sequence-gap based)
+		 sample_packets_lost_rtcp, // as reported via RTCP RR
 		 sample_duplicates;
 
 	int64_t next_rtcp; // for self-generated RTCP reports
@@ -93,7 +94,8 @@ struct ssrc_entry_call {
 	// input only - tracking for passthrough handling
 	uint32_t last_seq_tracked;
 	uint32_t lost_bits; // sliding bitfield, [0] = ext_seq
-	uint32_t packets_lost; // RTCP cumulative number of packets lost
+	uint32_t packets_lost; // locally measured (sequence-gap based) cumulative packets lost
+	uint32_t packets_lost_rtcp; // RTCP cumulative number of packets lost (RR)
 	uint32_t duplicates;
 
 	// for transcoding


### PR DESCRIPTION
At least in this version of RTPengine (13.5.1) there are 3 different metrics for packet loss that can be exported via MQTT:
* in voipmetrics, based on RTCP packets
* in rate, that requires kernel mode to work, but is not feasible for us at the moment
* for each ssrc, even in userspace mode can measure the detected packet loss locally

Currently the one that fits better the our goal, to measure packets lost per second in userspace it would be the last one and if we want to have a general view we can sum them up together so we can see all the lost packets on a particular interface...

However, there is a catch, that individual ssrcs are not only measuring local packet loss but also accounting for RTCP messages and the problem is when an RTCP packet, it resets the local counters

<img width="2677" height="1434" alt="image" src="https://github.com/user-attachments/assets/b0fc57a5-1577-488c-ae14-a8ca0df01b31" />

you can see the red line is just counting rtcp messages, because it's not actually detecting local loss, and the orange one is increasing steadily for local counters, but dropping whenever there is a RTCP packet received breaking the packet lost per second

I've come across this line in this PR, and disabling it, it works like a charm.

Is there any reason for that? Could we define different metrics for rtcp based packet loss and local measured packet loss, worst case scenario could there be a way to enable/disable rtcp metrics with a flag?

Thanks