### PR TITLE
Skip x64 asm objects for non-x86_64 builds

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -74,6 +74,8 @@ endif
 CFLAGS += $(CFLAGS_MQTT)
 LDLIBS += $(LDLIBS_MQTT)
 
+CC_ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine 2>/dev/null)))
+
 SRCS := main.c kernel.c helpers.c control_tcp.c call.c control_udp.c redis.c \
 		cookie_cache.c udp_listener.c control_ng_flags_parser.c control_ng.c sdp.strhash.c stun.c rtcp.c \
 		crypto.c rtp.c call_interfaces.c dtls.c log.c cli.strhash.c graphite.c ice.c \
@@ -87,7 +89,9 @@ LIBSRCS := loglib.c auxlib.c rtplib.c str.c socket.c streambuf.c ssllib.c dtmfli
 		bufferpool.c bencode.c netfilter_api.c
 ifeq ($(with_transcoding),yes)
 LIBSRCS += codeclib.strhash.c resample.c
+ifeq ($(CC_ARCH),x86_64)
 LIBASM := mvr2s_x64_avx2.S mvr2s_x64_avx512.S mix_in_x64_avx2.S mix_in_x64_avx512bw.S mix_in_x64_sse2.S
+endif
 endif
 ifneq ($(have_liburing),yes)
 LIBSRCS += uring.c

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -17,7 +17,11 @@ SRCS += netfilter_api.c oauth.c poller.c resample.c
 SRCS += rtplib.c s3utils.c socket.c
 SRCS += ssllib.c str.c streambuf.c uring.c
 
+CC_ARCH := $(firstword $(subst -, ,$(shell $(CC) -dumpmachine 2>/dev/null)))
+
+ifeq ($(CC_ARCH),x86_64)
 ASM := mix_in_x64_avx2.S mix_in_x64_avx512bw.S mix_in_x64_sse2.S mvr2s_x64_avx2.S mvr2s_x64_avx512.S
+endif
 
 include common.Makefile
 


### PR DESCRIPTION
## Why

`rtpengine` already has conservative non-`x86_64` fallbacks in its codec and mixing code, but the build system still unconditionally adds several `x64` assembly objects to `lib` and `daemon`.

For `riscv64`, that means the source-level generic path exists, but the makefile plan still tries to carry `mix_in_x64_*` and `mvr2s_x64_*` objects into the build.

This patch keeps the existing `x86_64` fast path intact and only makes the object selection follow the compiler target architecture.

## What changed

- Updated `lib/Makefile`:
  - detect the compiler target architecture with `$(CC) -dumpmachine`;
  - only add `mix_in_x64_*` and `mvr2s_x64_*` assembly objects when the target architecture is `x86_64`.
- Updated `daemon/Makefile`:
  - use the same compiler-target detection;
  - only add transcoding-related `x64` assembly objects when the target architecture is `x86_64`.

## Verification

- Verified the intended source-level behavior before touching the build scripts:
  - `lib/codeclib.c` and `lib/mix_buffer.c` already keep x86-specific SIMD dispatch behind `__x86_64__` guards and provide generic fallbacks elsewhere.
- Verified the patched build plans in Docker (`ubuntu:24.04`) with `make -pn`:
  - with host `gcc`, `lib/Makefile` still reports `CC_ARCH := x86_64` and keeps `ASM := mix_in_x64_* mvr2s_x64_*`;
  - with host `gcc`, `daemon/Makefile` still reports `CC_ARCH := x86_64` and keeps `LIBASM := mvr2s_x64_* mix_in_x64_*`;
  - with `CC=riscv64-linux-gnu-gcc`, `lib/Makefile` reports `CC_ARCH := riscv64` and no longer includes any `mix_in_x64_*` or `mvr2s_x64_*` assembly objects;
  - with `CC=riscv64-linux-gnu-gcc`, `daemon/Makefile` reports `CC_ARCH := riscv64` and no longer includes any `x64` assembly objects;
  - a final scan over both `make -pn` outputs confirmed no `mix_in_x64` or `mvr2s_x64` objects remain in the `riscv64` build plan.
- Verified the object-selection behavior by actually executing the patched `daemon/Makefile` rules in Docker (`ubuntu:24.04`) with a fake compiler harness:
  - when the fake compiler reports `riscv64-unknown-linux-gnu`, the `rtpengine` target builds without touching any `mix_in_x64_*` or `mvr2s_x64_*` assembly objects;
  - when the same harness reports `x86_64-linux-gnu`, the `rtpengine` target still compiles `mvr2s_x64_avx2.S`, `mvr2s_x64_avx512.S`, `mix_in_x64_avx2.S`, `mix_in_x64_avx512bw.S`, and `mix_in_x64_sse2.S`;
  - this confirms the patch changes the actual object-selection boundary, not just the printed plan.

## Notes

- This is a conservative portability patch. It does not add RVV or any RISC-V-specific optimized backend.
- The goal is to stop non-`x86_64` targets from inheriting `x64` assembly objects when the generic C path is already the correct fallback.