### PR TITLE
Set valid decrypt fields for non-forwarding kernel targets

### DIFF
--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -1629,6 +1629,9 @@ static const char *kernelize_target(kernelize_state *s, struct packet_stream *st
 		// nothing to forward
 		s->non_forwarding = true;
 		s->blackhole = true;
+		reti->non_forwarding = 1;
+		reti->decrypt.cipher = REC_NULL;
+		reti->decrypt.hmac = REH_NULL;
 		return NULL;
 	}
 


### PR DESCRIPTION
In case of the reverse direction of a subscription, no stream handler will be found. Previously, the decrypt struct was left zeroed, the kernel module rejected this with ``EINVAL`` and the daemon logged:

```
[core] Failed to push relay stream to kernel: Invalid argument
```

This patch sets ``REC_NULL``/``REH_NULL`` and marks the target as non-forwarding, matching what is expected by ``validate_srtp``.