### PR TITLE
Add option to enable/disable heuristic early-return logic

### DIFF
--- a/daemon/main.c
+++ b/daemon/main.c
@@ -882,6 +882,7 @@ static void options(int *argc, char ***argv, charp_ht templates) {
 		{ "mysql-pass",	0,   0,	G_OPTION_ARG_STRING,	&rtpe_config.mysql_pass,"MySQL connection credentials",		"PASSWORD"	},
 		{ "mysql-query",0,   0,	G_OPTION_ARG_STRING,	&rtpe_config.mysql_query,"MySQL select query",			"STRING"	},
 		{ "endpoint-learning",0,0,G_OPTION_ARG_STRING,	&endpoint_learning,	"RTP endpoint learning algorithm",	"delayed|immediate|off|heuristic"	},
+		{ "endpoint-learning-heuristic-disable-early-return",0,0,G_OPTION_ARG_NONE,	&rtpe_config.el_heuristic_disable_early_return, "Disable early return on heuristic endpoint-learning when there is a match that equals SDP address", NULL },
 		{ "jitter-buffer",0, 0,	G_OPTION_ARG_INT,	&rtpe_config.jb_length,	"Size of jitter buffer",		"INT" },
 		{ "jb-clock-drift",0,0,	G_OPTION_ARG_NONE,	&rtpe_config.jb_clock_drift,"Compensate for source clock drift",NULL },
 		{ "jb-adaptive",0,0,	G_OPTION_ARG_NONE,	&rtpe_config.jb_adaptive,"Enable adaptive jitter buffer sizing",NULL },

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -3255,7 +3255,7 @@ static bool media_packet_address_check(struct packet_handler_ctx *phc)
 		}
 
 		// confirm endpoint, if matches address advertised in SDP
-		if (idx == 0)
+		if (!rtpe_config.el_heuristic_disable_early_return && idx == 0)
 			goto confirm_now;
 
 		// finally, if there has been a better match and if strict-source is set,

--- a/docs/rtpengine.md
+++ b/docs/rtpengine.md
@@ -977,6 +977,16 @@ call to inject-DTMF won't be sent to __\-\-dtmf-log-dest=__ or __\-\-listen-tcp-
     (but different address) is seen, that address is used. Otherwise, the source
     address of any incoming packet seen is used.
 
+- __\-\-endpoint-learning-heuristic-disable-early-return__
+
+    When __endpoint-learning=heuristic__ is in use, an incoming RTP packet whose
+    source address and port exactly match the address advertised in the SDP causes
+    immediate endpoint confirmation, without waiting for the usual 3-second learning
+    period. Enable this option to disable that early return and restore the previous
+    behaviour of waiting out the full learning period before confirming, even when
+    an SDP-matching packet is seen. Has no effect unless __heuristic__ endpoint
+    learning is active. Disabled by default.
+
 - __\-\-jitter-buffer=__*INT*
 
     Size of (incoming) jitter buffer in packets. A value of zero (the default)

--- a/etc/rtpengine.conf
+++ b/etc/rtpengine.conf
@@ -42,6 +42,7 @@ tos = 184
 # delete-delay = 30
 # final-timeout = 10800
 # endpoint-learning = heuristic
+# endpoint-learning-heuristic-disable-early-return = true
 # reject-invalid-sdp = false
 
 # foreground = false

--- a/include/main.h
+++ b/include/main.h
@@ -140,6 +140,7 @@ enum endpoint_learning {
 	X(amr_cn_dtx) \
 	X(evs_cn_dtx) \
 	X(moh_prevent_double_hold) \
+	X(el_heuristic_disable_early_return) \
 
 #define RTPE_CONFIG_CHARP_PARAMS \
 	X(b2b_url) \


### PR DESCRIPTION
This PR is related to the following RTPEngine Forum question: (https://groups.google.com/g/rtpengine/c/YsTU99HGd2o).

After 13.5 (including) the following commit was introduced: (https://github.com/sipwise/rtpengine/commit/afce798034ae51704818d9bfb47aa87449da2637).

The idea of this commit is quiet good, but could affect some scenarios, like: when clients are behind some VPN's.

So, the proposal here, is to include a new parameter: `endpoint-learning-heuristic-disable-early-return`. This parameter by default assumes `false` as value (so, the current behavior is preserved). But, passing `true` as value, reverts the current behavior and preserves the old logic (<= 13.4).

The following PR was already tested locally, and allows the correct turn on/off.

If possible, a backport should be made for versions >= 13.5 (14.x also).