### PR TITLE
Fix locally measured jitter reporting

### DIFF
--- a/daemon/mqtt.c
+++ b/daemon/mqtt.c
@@ -315,7 +315,7 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 
 	if (clockrate) {
 		json_builder_set_member_name(json, "jitter");
-		json_builder_add_double_value(json, (double) jitter * 1000.0 / (double) clockrate);
+		json_builder_add_double_value(json, (double) (jitter >> 4) * 1000.0 / (double) clockrate);
 	}
 
 	if (mos != -1 && mos != 0) {

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -706,17 +706,18 @@ void ssrc_collect_metrics(struct call_media *media) {
 		// exclude zero values - technically possible but unlikely and probably just unset
 		if (!s->jitter)
 			continue;
+		uint32_t jitter = s->jitter >> 4;
 
 		if (s->tracker.most_len > 0 && s->tracker.most[0] != 255) {
 			const rtp_payload_type *rpt = get_rtp_payload_type(s->tracker.most[0],
 					&media->codecs);
 			if (rpt && rpt->clock_rate)
-				s->jitter = s->jitter * 1000 / rpt->clock_rate;
+				jitter = (uint64_t) jitter * 1000 / rpt->clock_rate;
 		}
 
 		if (media->streams.head) {
 			LOCK(&media->streams.head->data->lock);
-			RTPE_SAMPLE_SFD(jitter_measured, s->jitter, media->streams.head->data->selected_sfd);
+			RTPE_SAMPLE_SFD(jitter_measured, jitter, media->streams.head->data->selected_sfd);
 		}
 	}
 }


### PR DESCRIPTION
Summary:
- Convert the internal Q4 jitter estimator before exporting per-SSRC MQTT metrics.
- Keep the estimator in RTP timestamp units while sampling locally measured jitter.

Testing:
- docker build --target rtpengine -t rtpengine-local-jitter-fix-test .
- make -C t daemon-tests-measure-rtp