### PR TITLE
Fix locally measured jitter reporting

### DIFF
--- a/daemon/mqtt.c
+++ b/daemon/mqtt.c
@@ -306,7 +306,7 @@ static void mqtt_ssrc_stats(struct ssrc_entry_call *ssrc, JsonBuilder *json, str
 
 	if (clockrate) {
 		json_builder_set_member_name(json, "jitter");
-		json_builder_add_double_value(json, (double) jitter * 1000.0 / (double) clockrate);
+		json_builder_add_double_value(json, (double) (jitter >> 4) * 1000.0 / (double) clockrate);
 	}
 
 	if (mos != -1 && mos != 0) {

--- a/daemon/ssrc.c
+++ b/daemon/ssrc.c
@@ -706,17 +706,18 @@ void ssrc_collect_metrics(struct call_media *media) {
 		// exclude zero values - technically possible but unlikely and probably just unset
 		if (!s->jitter)
 			continue;
+		uint32_t jitter = s->jitter >> 4;
 
 		if (s->tracker.most_len > 0 && s->tracker.most[0] != 255) {
 			const rtp_payload_type *rpt = get_rtp_payload_type(s->tracker.most[0],
 					&media->codecs);
 			if (rpt && rpt->clock_rate)
-				s->jitter = s->jitter * 1000 / rpt->clock_rate;
+				jitter = (uint64_t) jitter * 1000 / rpt->clock_rate;
 		}
 
 		if (media->streams.head) {
 			LOCK(&media->streams.head->data->lock);
-			RTPE_SAMPLE_SFD(jitter_measured, s->jitter, media->streams.head->data->selected_sfd);
+			RTPE_SAMPLE_SFD(jitter_measured, jitter, media->streams.head->data->selected_sfd);
 		}
 	}
 }


### PR DESCRIPTION
Correct locally measured RTP jitter values before exporting them through MQTT and collecting aggregate metrics. The internal jitter estimator uses Q4 fixed-point representation, so the previous code reported values up to 16 times too large and could corrupt the estimator by replacing its internal state with a value converted to milliseconds.

Detailed changes:

- Correct per-SSRC MQTT jitter scaling in daemon/mqtt.c.

  Convert the internal Q4 jitter value to regular RTP timestamp units with a four-bit right shift before converting it to milliseconds using the payload clock rate.

  The RTP jitter estimator stores the value multiplied by 16, as required by its fixed-point update algorithm. Exporting it without this conversion caused the MQTT jitter value to be approximately 16 times too large.

- Preserve the jitter estimator state in daemon/ssrc.c.

  Copy the internal jitter value into a local variable, convert that copy from Q4 representation, and use it when collecting the locally measured jitter sample.

  Previously, metric collection converted s->jitter to milliseconds in place. This replaced the estimator's fixed-point RTP timestamp state with a value in different units. Subsequent packet processing and repeated metric collection therefore operated on corrupted estimator state.

- Use a 64-bit intermediate for conversion to milliseconds.

  Perform the multiplication by 1000 using a uint64_t intermediate before dividing by the RTP clock rate. This prevents overflow during conversion while retaining the existing integer-millisecond metric representation.

These changes keep the estimator in its required internal representation while ensuring that locally measured jitter is consistently exported and sampled in milliseconds. RTCP-reported jitter processing remains unchanged.