### PR TITLE
kernel-module: scrub forwarded skb metadata

### DIFF
--- a/kernel-module/nft_rtpengine.c
+++ b/kernel-module/nft_rtpengine.c
@@ -5590,6 +5590,11 @@ static int send_proxy_packet(struct sk_buff *skb, const struct re_address *src, 
 		goto drop;
 	}
 
+	/* This skb was received from the network but is now being reinjected as
+	 * a new locally generated packet. Drop inherited routing, conntrack, and
+	 * netfilter metadata before handing it to the IP output path. */
+	skb_scrub_packet(skb, true);
+
 	switch (src->family) {
 		case AF_INET:
 			return send_proxy_packet4(skb, src, dst, tos, net);


### PR DESCRIPTION
## Summary

- scrub metadata inherited from the received skb before proxy reinjection
- retain the existing per-family queue mapping safeguards

## Problem

The kernel module reuses an skb received from the network when constructing a rewritten proxy output packet. The per-family output paths clear selected fields, but the skb can still carry ingress routing, conntrack, skb extension, and netfilter metadata.

When the rewritten packet enters the local output path, that inherited state can cause it to be treated as part of the original ingress flow and routed back through an RTPengine target. The packet can then be processed repeatedly instead of being emitted once.

## Fix

Call `skb_scrub_packet(skb, true)` at the shared `send_proxy_packet()` boundary, where the ingress skb changes roles into a newly generated egress packet. The existing queue mapping reset remains necessary because `skb_scrub_packet()` deliberately does not clear that field.

## Verification

- compiled `nft_rtpengine.ko` from this branch against Linux 5.15, 6.8, and 6.18 headers
- standalone IPv4 kernel-forwarding smoke:
  - bidirectional RTP: 400 packets received in each direction, kernel counter delta 800, idle delta 0
  - RTP to SDES-SRTP: 120 packets received, kernel counter delta 120, idle delta 0
- verified that packet counters stop increasing after senders become idle
