### PR TITLE
fix: add guard to avoid packet sent on shutdown on already dead streams

### DIFF
--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -646,6 +646,8 @@ static long dtls_bio_callback(BIO *bio, int oper, const char *argp, size_t len, 
 	struct stream_fd *sfd = d->sfd;
 	if (!sfd)
 		return ret;
+	if (!sfd->socket.family || sfd->socket.fd < 0)
+		return ret;
 
 	__DBG("dtls packet output: len %zu %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
 		len,

--- a/daemon/dtls.c
+++ b/daemon/dtls.c
@@ -646,7 +646,7 @@ static long dtls_bio_callback(BIO *bio, int oper, const char *argp, size_t len, 
 	struct stream_fd *sfd = d->sfd;
 	if (!sfd)
 		return ret;
-	if (!sfd->socket.family || sfd->socket.fd < 0)
+	if (!sfd->socket.family)
 		return ret;
 
 	__DBG("dtls packet output: len %zu %02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",


### PR DESCRIPTION
This PR is related to the issue: [2146](https://github.com/sipwise/rtpengine/issues/2146).

The fix results from gdb analysis, and uses a similar approach that was used previously on similar problems like: (https://github.com/linuxmaniac/rtpengine/commit/ceb7996ccadd03797ce4dd6de64dffe8c7c5caa1).

I already have tested it, and crashes are not happening anymore.