### PR TITLE
Disable loop check when remote endpoint is no longer local

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2275,8 +2275,12 @@ static void media_loop_protect(struct stream_params *sp, struct call_media *medi
 	intf_addr.addr = sp->rtp_endpoint.address;
 	if (!intf_addr.addr.family) // dummy/empty address
 		return;
-	if (!is_local_endpoint(&intf_addr, sp->rtp_endpoint.port))
+	if (!is_local_endpoint(&intf_addr, sp->rtp_endpoint.port)) {
+		if (MEDIA_ISSET(media, LOOP_CHECK))
+			ilog(LOG_DEBUG, "Remote endpoint is no longer local, disabling loop checking");
+		MEDIA_CLEAR(media, LOOP_CHECK);
 		return;
+	}
 
 	ilog(LOG_DEBUG, "Detected local endpoint advertised by remote client, "
 			"enabling loop checking");

--- a/t/auto-daemon-tests.pl
+++ b/t/auto-daemon-tests.pl
@@ -29551,6 +29551,101 @@ rcv($sock_b, $port_d, rtpm(98, 8000, 9000, 0xa234, "b"));
 
 
 
+# Scenario: initial offer uses a local daemon address (203.0.113.1), triggering LOOP_CHECK. A
+# re-INVITE changes the endpoint to non-local, which should clear it.
+new_call;
+
+offer('loop check cleared on non-local re-INVITE', { }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+c=IN IP4 203.0.113.1
+t=0 0
+m=audio 30130 RTP/AVP 0
+a=sendrecv
+----------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 0
+c=IN IP4 203.0.113.1
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+answer('loop check cleared on non-local re-INVITE', { }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+c=IN IP4 198.51.100.3
+t=0 0
+m=audio 6132 RTP/AVP 0
+a=sendrecv
+----------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 0
+c=IN IP4 203.0.113.1
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+$resp = rtpe_req('query', 'loop check cleared on non-local re-INVITE', { });
+ok(grep($_ eq 'loop check', @{$resp->{tags}{ft()}{medias}[0]{flags}}),
+	'loop check flag set with local endpoint');
+
+# re-INVITE: endpoint changes to non-local address
+offer('loop check cleared on non-local re-INVITE', { }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+c=IN IP4 198.51.100.1
+t=0 0
+m=audio 6130 RTP/AVP 0
+a=sendrecv
+----------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 0
+c=IN IP4 203.0.113.1
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+answer('loop check cleared on non-local re-INVITE', { }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+c=IN IP4 198.51.100.3
+t=0 0
+m=audio 6132 RTP/AVP 0
+a=sendrecv
+----------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.14
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 0
+c=IN IP4 203.0.113.1
+a=rtpmap:0 PCMU/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+$resp = rtpe_req('query', 'loop check cleared on non-local re-INVITE', { });
+ok(!grep($_ eq 'loop check', @{$resp->{tags}{ft()}{medias}[0]{flags}}),
+	'loop check flag cleared after non-local re-INVITE');
+
+
+
 
 #done_testing;NGCP::Rtpengine::AutoTest::terminate('f00');exit;
 done_testing();


### PR DESCRIPTION
Previously, once rtpengine detected that the remote endpoint of a session is a local endpoint, the loop check would be permanently enabled for that session. A renegotiation that changes the remote endpoint to be non-local, did not cause the check to be turned off again. This patch addresses that.