### PR TITLE
Don't restart DTLS after receiving new tls-id while passive

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2228,8 +2228,13 @@ static void __dtls_logic(const sdp_ng_flags *flags,
 	}
 	else if (other_media->tls_id.len && (sp->tls_id.len == 0 || str_cmp_str(&other_media->tls_id, &sp->tls_id))) {
 		// previously seen tls-id and new tls-id is different or not present
-		ilogs(crypto, LOG_INFO, "TLS-ID changed, restarting DTLS");
-		__dtls_restart(other_media);
+		if (MEDIA_ISSET(other_media, SETUP_PASSIVE) && !MEDIA_ISSET(other_media, SETUP_ACTIVE)) {
+			// passive: active peer controls DTLS restart
+			ilogs(crypto, LOG_INFO, "TLS-ID changed, passive role, not restarting DTLS");
+		} else {
+			ilogs(crypto, LOG_INFO, "TLS-ID changed, restarting DTLS");
+			__dtls_restart(other_media);
+		}
 	}
 	else if (ice_is_restart(other_media->ice_agent, sp) && !other_media->tls_id.len && !sp->tls_id.len) {
 		// Skip DTLS restart if no-tls-id flag is active (user opted out of TLS-ID handling)


### PR DESCRIPTION
When the remote end of a DTLS media session changes their ``tls-id`` in their answer in response to a re-INVITE, they are the one to initiate a new DTLS handshake. Previously, rtpengine would always perform a DTLS restart after seeing a new ``tls-id``, even if rtpengine's DTLS role is currently passive. This could abort an in-progress handshake, leaving the remote end retransmitting DTLS packets without ever getting a response. This patch addresses that.