### PR TITLE
Add `force strip extmap` flag

### DIFF
--- a/daemon/call.c
+++ b/daemon/call.c
@@ -2762,6 +2762,8 @@ static void __call_monologue_init_from_flags(struct call_monologue *ml, struct c
 
 	call->last_signal_us = rtpe_now;
 	call->deleted_us = 0;
+	if (flags->force_strip_extmap)
+		CALL_SET(call, FORCE_STRIP_EXTMAP);
 	call->media_rec_slots = (flags->media_rec_slots > 0 && call->media_rec_slots == 0)
 								? flags->media_rec_slots
 								: call->media_rec_slots;

--- a/daemon/call_flags.c
+++ b/daemon/call_flags.c
@@ -970,6 +970,10 @@ const char *call_ng_flags_flags(str *s, unsigned int idx, helper_arg arg) {
 		case CSH_LOOKUP("strip-extmap"):
 		case CSH_LOOKUP("strip extmap"):
 			return call_ng_flags_str_ht(STR_PTR("all"), 0, &out->rtpext_strip);
+		case CSH_LOOKUP("force-strip-extmap"):
+		case CSH_LOOKUP("force strip extmap"):
+			out->force_strip_extmap = true;
+			break;
 		case CSH_LOOKUP("symmetric-codecs"):
 		case CSH_LOOKUP("symmetric codecs"):
 			ilog(LOG_INFO, "Ignoring obsolete flag `symmetric-codecs`");

--- a/daemon/media_socket.c
+++ b/daemon/media_socket.c
@@ -2545,7 +2545,10 @@ static void __determine_rtpext_handler(struct call_media *in, struct call_media 
 	if (!sh || !out)
 		return;
 
-	if (in->extmap.length || out->extmap.length)
+	/* With `force strip extmap` set on the call, use the extmap printer even
+	 * if no header extensions were negotiated, so that unannounced header
+	 * extensions are removed from forwarded RTP. */
+	if (in->extmap.length || out->extmap.length || CALL_ISSET(out->call, FORCE_STRIP_EXTMAP))
 		sh->rtpext = &rtpext_printer_extmap;
 	else
 		sh->rtpext = &rtpext_printer_copy;

--- a/docs/ng_control_protocol.md
+++ b/docs/ng_control_protocol.md
@@ -1361,6 +1361,15 @@ Spaces in each string may be replaced by hyphens.
     Legacy alias for `extmap=[strip=[all]]` to remove all `a=rtpmap` attributes
     from the outgoing SDP.
 
+* `force strip extmap`
+
+    Process RTP header extensions of forwarded media even if no header
+    extensions were negotiated in the SDP. Normally, RTP header extensions
+    are passed through untouched if neither side included any `a=extmap`
+    attributes. With this flag set, header extensions that were not
+    negotiated are removed from forwarded RTP. Once set, the flag remains
+    in effect for the lifetime of the call.
+
 * `strict source`
 
 	Normally, *rtpengine* attempts to learn the correct endpoint address for every stream during

--- a/include/call.h
+++ b/include/call.h
@@ -255,6 +255,7 @@ enum {
 #define CALL_FLAG_BLOCK_MEDIA			(1LL << 28)
 #define CALL_FLAG_SILENCE_MEDIA			(1LL << 29)
 #define CALL_FLAG_NO_REC_DB			(1LL << 30)
+#define CALL_FLAG_FORCE_STRIP_EXTMAP		(1LL << 31)
 
 /* access macros */
 #define SP_ISSET(p, f)		bf_isset(&(p)->sp_flags, SP_FLAG_ ## f)

--- a/include/call_flags.h
+++ b/include/call_flags.h
@@ -323,7 +323,9 @@ RTPE_NG_FLAGS_STR_CASE_HT_PARAMS
 		     moh_sendrecv:1,
 		     moh_reflect:1,
 		     /* prevents double MoH holds */
-		     moh_double_hold:1;
+		     moh_double_hold:1,
+		     /* process RTP header extensions even if none were negotiated */
+		     force_strip_extmap:1;
 };
 
 

--- a/t/auto-daemon-tests-rtp-ext.pl
+++ b/t/auto-daemon-tests-rtp-ext.pl
@@ -4026,5 +4026,62 @@ srtp_snd($sock_b, $port_a, rtp( 0, 8000, 7000+160*0, 0x6543, "\x39" . ("\x29" x 
 
 
 
+# force strip extmap: header extensions removed even though none were negotiated
+
+($sock_a, $sock_ax, $sock_b, $sock_bx) = new_call(
+	[qw(198.51.100.1 7690)],
+	[qw(198.51.100.1 7691)],
+	[qw(198.51.100.3 7692)],
+	[qw(198.51.100.3 7693)],
+);
+
+($port_a, $port_ax) = offer('force strip extmap', { flags => ['force strip extmap'] }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio 7690 RTP/AVP 8
+c=IN IP4 198.51.100.1
+a=sendrecv
+----------------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.1
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 8
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+($port_b, $port_bx) = answer('force strip extmap', { }, <<SDP);
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.3
+s=tester
+t=0 0
+m=audio 7692 RTP/AVP 8
+c=IN IP4 198.51.100.3
+a=rtpmap:8 PCMA/8000
+a=sendrecv
+--------------------------------------
+v=0
+o=- 1545997027 1 IN IP4 198.51.100.3
+s=tester
+t=0 0
+m=audio PORT RTP/AVP 8
+c=IN IP4 203.0.113.1
+a=rtpmap:8 PCMA/8000
+a=sendrecv
+a=rtcp:PORT
+SDP
+
+snd($sock_a, $port_b, rtp( 8, 1000, 3000+160*0, 0x1234, "\x10" . ("\x00" x 158) . "\x50", [[1, "foo"]]));
+rcv($sock_b, $port_a, rtpm(8, 1000, 3000+160*0, 0x1234, "\x10" . ("\x00" x 158) . "\x50"));
+snd($sock_b, $port_a, rtp( 8, 8000, 7000+160*0, 0x6543, "\x10" . ("\x00" x 158) . "\x50", [[2, "blah"]]));
+rcv($sock_a, $port_b, rtpm(8, 8000, 7000+160*0, 0x6543, "\x10" . ("\x00" x 158) . "\x50"));
+snd($sock_a, $port_b, rtp( 8, 1001, 3000+160*1, 0x1234, "\x10" . ("\x00" x 158) . "\x50"));
+rcv($sock_b, $port_a, rtpm(8, 1001, 3000+160*1, 0x1234, "\x10" . ("\x00" x 158) . "\x50"));
+
 #done_testing;NGCP::Rtpengine::AutoTest::terminate('f00');exit;
 done_testing();


### PR DESCRIPTION
RTP header extensions are only processed, and unknown ones removed, if at
least one side of the call negotiated header extensions through `a=extmap`
attributes in the SDP. Otherwise RTP is forwarded untouched, including any
header extensions an endpoint sends without having announced them.

This adds a `force strip extmap` flag that turns on header extension
processing for all streams of a call regardless of whether any extensions
were negotiated, so that unannounced header extensions are removed from
forwarded RTP. The flag is remembered for the lifetime of the call, so it
only needs to be given once.

Use case: media coming from a WebRTC selective forwarding unit carries
header extensions that WebRTC clients use among themselves (audio level,
transport-wide congestion control) but which were never part of the SIP
side's SDP. Some SIP endpoints do not cope with unexpected header
extensions, and with this flag rtpengine can strip them selectively on
such routes.

Tests: a case in `t/auto-daemon-tests-rtp-ext.pl` sends RTP with header
extensions in both directions on a call without any `a=extmap` and checks
that they arrive without the extensions.
