### PR TITLE
Report the fixed egress SSRC in `query`

### DIFF
--- a/daemon/call_interfaces.c
+++ b/daemon/call_interfaces.c
@@ -961,6 +961,11 @@ static void ng_stats_media(ng_command_ctx_t *ctx, parser_arg list, const struct 
 	if (rtp_pt)
 		parser->dict_add_str_dup(dict, "codec", &rtp_pt->encoding_with_params);
 
+	/* available right away, unlike the `egress SSRCs` list below, which only
+	 * fills in once a packet has been forwarded */
+	if (m->fixed_egress_ssrc)
+		parser->dict_add_int(dict, "fixed egress SSRC", m->fixed_egress_ssrc);
+
 	streams = parser->dict_add_list(dict, "streams");
 
 	flags = parser->dict_add_list(dict, "flags");

--- a/docs/ng_control_protocol.md
+++ b/docs/ng_control_protocol.md
@@ -1385,6 +1385,8 @@ Spaces in each string may be replaced by hyphens.
     its own SSRC mid-call is still forwarded under the same one, with the
     sequence numbering carried across the change.
 
+    The same values are reported per media in the `query` response.
+
     Intended for feeding media into a system that has to bind a receiver to an
     SSRC up front, such as a WebRTC selective forwarding unit.
 
@@ -2049,6 +2051,12 @@ The response dictionary contains the following keys:
 
 			If the protocol is recognized by *rtpengine*, this string contains it.
 			Usually `RTP/AVP` or `RTP/SAVPF`.
+
+		+ `fixed egress SSRC`
+
+			The SSRC used for all RTP sent towards this media, if the
+			`fixed egress SSRC` flag was given. Reported as soon as the flag
+			takes effect, before any media has been forwarded.
 
 		+ `flags`
 

--- a/t/auto-daemon-tests-ssrc.pl
+++ b/t/auto-daemon-tests-ssrc.pl
@@ -78,6 +78,16 @@ a=rtcp:PORT
 SDP
 
 
+# the same values are reported per media by `query`, before any media has flowed
+
+$resp = rtpe_req('query', 'egress SSRC in query', { 'call-id' => cid() });
+
+is $resp->{tags}{tt()}{medias}[0]{'fixed egress SSRC'}, $egress,
+		'query reports the fixed egress SSRC facing the answerer';
+ok(($resp->{tags}{ft()}{medias}[0]{'fixed egress SSRC'} // 0) > 0,
+		'query reports a fixed egress SSRC facing the offerer as well');
+
+
 # RTP towards the answerer carries the reported SSRC, not the one the sender used
 
 snd($sock_a, $port_b, rtp(8, 1000, 3000, 0x1234, "\x00" x 160));


### PR DESCRIPTION
Small follow up to the `fixed egress SSRC` flag.

The SSRC only appears in the offer or answer response. Currently no way to
read it before media flows. This adds `fixed egress SSRC` to each media in
the `query` and `delete` responses.